### PR TITLE
Add TypeScript definition for @gnomad/ui

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnomad/ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "types": "lib/index.d.ts",
   "license": "MIT",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@gnomad/ui",
   "version": "1.0.0",
+  "types": "lib/index.d.ts",
   "license": "MIT",
   "repository": {
     "type" : "git",
@@ -15,7 +16,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "gnomad-browser-toolkit-scripts build",
+    "build": "gnomad-browser-toolkit-scripts build && yarn run copy-type-def",
+    "copy-type-def": "cp src/index.d.ts lib/",
     "prepack": "yarn run build",
     "example": "gnomad-browser-toolkit-scripts example"
   },

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -23,10 +23,10 @@ export interface GridProps<RowDatum, CellData> {
   onHoverRow?: (rowIndex: number) => void
   onRequestSort?: (columnKey: string) => void
   onScroll?: FixedSizeListProps['onScroll']
-  onVisibleRowsChange?: () => void
+  onVisibleRowsChange?: (range: {startIndex: number, stopIndex: number}) => void
   rowHeight?: number
   rowKey?: (rowDatum: RowDatum) => string
-  shouldHighlightRow?: () => boolean
+  shouldHighlightRow?: (rowDatum: RowDatum) => boolean
   sortKey?: string
   sortOrder?: 'ascending' | 'descending'
 }
@@ -71,9 +71,9 @@ interface SearchBoxItem<Value> {
 }
 
 export interface SearchBoxProps<Value, Item extends SearchBoxItem<Value>> {
-  fetchSearchResult: (query: string) => Promise<Item[]>
+  fetchSearchResults: (query: string) => Promise<Item[]>
   id?: string
-  onSelect: (itemValue: Value) => void
+  onSelect: (itemValue: Value, item: Item) => void
   placeholder?: string
   width?: number
 }

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,52 +1,60 @@
-import React from 'react'
-import { FixedSizeList, FixedSizeListProps } from 'react-window'
-import { StyledComponent } from 'styled-components'
+import React from "react";
+import { FixedSizeListProps } from "react-window";
+import { StyledComponent } from "styled-components";
 
-export interface ColumnRenderer<RowDatum, CellData> {
-  (rowDatum: RowDatum, columnKey: string, cellData: CellData): React.ReactNode
+export interface ColumnRenderer<RowDatum, CellDatum> {
+  (
+    rowDatum: RowDatum,
+    columnKey: string,
+    cellData: CellDatum
+  ): React.ReactNode;
 }
 
 export interface GridPropsColumn<RowDatum, CellData> {
-  heading?: string
-  key: string
-  isRowHeader?: boolean
-  isSortable?: boolean
-  minWidth?: number
-  tooltip?: string
-  render: ColumnRenderer<RowDatum, CellData>
+  heading?: string;
+  key: string;
+  isRowHeader?: boolean;
+  isSortable?: boolean;
+  minWidth?: number;
+  tooltip?: string;
+  render: ColumnRenderer<RowDatum, CellData>;
 }
 export interface GridProps<RowDatum, CellData> {
-  columns: GridPropsColumn<RowDatum, CellData>[]
-  cellData?: CellData
-  data: RowDatum[]
-  numRowsRendered?: number
-  onHoverRow?: (rowIndex: number) => void
-  onRequestSort?: (columnKey: string) => void
-  onScroll?: FixedSizeListProps['onScroll']
-  onVisibleRowsChange?: (range: {startIndex: number, stopIndex: number}) => void
-  rowHeight?: number
-  rowKey?: (rowDatum: RowDatum) => string
-  shouldHighlightRow?: (rowDatum: RowDatum) => boolean
-  sortKey?: string
-  sortOrder?: 'ascending' | 'descending'
+  columns: GridPropsColumn<RowDatum, CellData>[];
+  cellData?: CellData;
+  data: RowDatum[];
+  numRowsRendered?: number;
+  onHoverRow?: (rowIndex: number) => void;
+  onRequestSort?: (columnKey: string) => void;
+  onScroll?: FixedSizeListProps["onScroll"];
+  onVisibleRowsChange?: (range: {startIndex: number, stopIndex: number}) => void;
+  rowHeight?: number;
+  rowKey?: (rowDatum: RowDatum) => string;
+  shouldHighlightRow?: (rowDatum: RowDatum) => boolean;
+  sortKey?: string;
+  sortOrder?: "ascending" | "descending";
 }
 
-export class Grid<RowDatum, CellData = {}> extends React.Component<GridProps<RowDatum, CellData>> {}
+export class Grid<RowDatum, CellData = {}> extends React.Component<
+  GridProps<RowDatum, CellData>
+> {}
 
 interface Option<OptionValue extends boolean | number | string> {
-  disabled?: boolean
-  label?: string
-  value: OptionValue
+  disabled?: boolean;
+  label?: string;
+  value: OptionValue;
 }
-export interface SegmentedControlProps<OptionValue extends boolean | number | string> {
-  backgroundColor?: string
-  borderColor?: string
-  disabled?: boolean
-  id: string
-  onChange: (value: OptionValue) => void
-  options: Option<OptionValue>[]
-  textColor?: string
-  value: OptionValue
+export interface SegmentedControlProps<
+  OptionValue extends boolean | number | string
+> {
+  backgroundColor?: string;
+  borderColor?: string;
+  disabled?: boolean;
+  id: string;
+  onChange: (value: OptionValue) => void;
+  options: Option<OptionValue>[];
+  textColor?: string;
+  value: OptionValue;
 }
 
 export class SegmentedControl<
@@ -54,31 +62,31 @@ export class SegmentedControl<
 > extends React.Component<SegmentedControlProps<OptionValue>> {}
 
 export interface CheckboxProps {
-  checked: boolean
-  disabled?: boolean
-  id: string
-  label: string
-  onChange: (isChecked: boolean) => void
+  checked: boolean;
+  disabled?: boolean;
+  id: string;
+  label: string;
+  onChange: (isChecked: boolean) => void;
 }
 
 export class Checkbox extends React.Component<CheckboxProps> {}
 
-export const Link: StyledComponent<'a', any, {}, never>
+export const Link: StyledComponent<"a", any, {}, never>;
 
 interface SearchBoxItem<Value> {
-  label: string
-  value: Value
+  label: string;
+  value: Value;
 }
 
-export interface SearchBoxProps<Value, Item extends SearchBoxItem<Value>> {
-  fetchSearchResults: (query: string) => Promise<Item[]>
-  id?: string
-  onSelect: (itemValue: Value, item: Item) => void
-  placeholder?: string
-  width?: number
+export interface SearchboxProps<Value, Item extends SearchBoxItem<Value>> {
+  fetchSearchResults: (query: string) => Promise<Item[]>;
+  id?: string;
+  onSelect: (itemValue: Value, item: Item) => void;
+  placeholder?: string;
+  width?: number;
 }
 
-export class SearchBox<
+export class Searchbox<
   Value,
   Item extends SearchBoxItem<Value> = SearchBoxItem<Value>
-> extends React.Component<SearchBoxProps<Value, Item>> {}
+> extends React.Component<SearchboxProps<Value, Item>> {}

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,0 +1,84 @@
+import React from 'react'
+import { FixedSizeList, FixedSizeListProps } from 'react-window'
+import { StyledComponent } from 'styled-components'
+
+export interface ColumnRenderer<RowDatum, CellData> {
+  (rowDatum: RowDatum, columnKey: string, cellData: CellData): React.ReactNode
+}
+
+export interface GridPropsColumn<RowDatum, CellData> {
+  heading?: string
+  key: string
+  isRowHeader?: boolean
+  isSortable?: boolean
+  minWidth?: number
+  tooltip?: string
+  render: ColumnRenderer<RowDatum, CellData>
+}
+export interface GridProps<RowDatum, CellData> {
+  columns: GridPropsColumn<RowDatum, CellData>[]
+  cellData?: CellData
+  data: RowDatum[]
+  numRowsRendered?: number
+  onHoverRow?: (rowIndex: number) => void
+  onRequestSort?: (columnKey: string) => void
+  onScroll?: FixedSizeListProps['onScroll']
+  onVisibleRowsChange?: () => void
+  rowHeight?: number
+  rowKey?: (rowDatum: RowDatum) => string
+  shouldHighlightRow?: () => boolean
+  sortKey?: string
+  sortOrder?: 'ascending' | 'descending'
+}
+
+export class Grid<RowDatum, CellData = {}> extends React.Component<GridProps<RowDatum, CellData>> {}
+
+interface Option<OptionValue extends boolean | number | string> {
+  disabled?: boolean
+  label?: string
+  value: OptionValue
+}
+export interface SegmentedControlProps<OptionValue extends boolean | number | string> {
+  backgroundColor?: string
+  borderColor?: string
+  disabled?: boolean
+  id: string
+  onChange: (value: OptionValue) => void
+  options: Option<OptionValue>[]
+  textColor?: string
+  value: OptionValue
+}
+
+export class SegmentedControl<
+  OptionValue extends boolean | number | string
+> extends React.Component<SegmentedControlProps<OptionValue>> {}
+
+export interface CheckboxProps {
+  checked: boolean
+  disabled?: boolean
+  id: string
+  label: string
+  onChange: (isChecked: boolean) => void
+}
+
+export class Checkbox extends React.Component<CheckboxProps> {}
+
+export const Link: StyledComponent<'a', any, {}, never>
+
+interface SearchBoxItem<Value> {
+  label: string
+  value: Value
+}
+
+export interface SearchBoxProps<Value, Item extends SearchBoxItem<Value>> {
+  fetchSearchResult: (query: string) => Promise<Item[]>
+  id?: string
+  onSelect: (itemValue: Value) => void
+  placeholder?: string
+  width?: number
+}
+
+export class SearchBox<
+  Value,
+  Item extends SearchBoxItem<Value> = SearchBoxItem<Value>
+> extends React.Component<SearchBoxProps<Value, Item>> {}

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -1,8 +1,107 @@
 import React from "react";
 import { FixedSizeListProps } from "react-window";
-import { StyledComponent } from "styled-components";
+import { StyledComponent, ThemedStyledFunction } from "styled-components";
 
-export interface ColumnRenderer<RowDatum, CellDatum> {
+/* Start of components exported by Button.js */
+export const BaseButton: StyledComponent<
+  "button",
+  any,
+  {
+    type: "button";
+  },
+  "type"
+>;
+export const Button: StyledComponent<
+  "button",
+  any,
+  {
+    type: "button";
+  } & {
+    backgroundColor: string;
+    borderColor: string;
+  },
+  "type" | "backgroundColor" | "borderColor"
+>;
+export const PrimaryButton: StyledComponent<
+  "button",
+  any,
+  {
+    type: "button";
+  } & {
+    backgroundColor: string;
+    borderColor: string;
+    textColor: string;
+  },
+  "type" | "backgroundColor" | "borderColor" | "textColor"
+>;
+export const TextButton: StyledComponent<
+  "button",
+  any,
+  {
+    type: "button";
+  },
+  "type"
+>;
+/* End of components exported by Button.js */
+
+/* Start of components exported by CategoryFilterControl.js */
+export interface FilterControlCategory {
+  id: string;
+  label: string;
+  className?: string;
+  color: string;
+}
+export interface CategoryFilterControlProps {
+  categories: FilterControlCategory[];
+  categorySelections: { [categoryId: string]: boolean };
+  className?: string;
+  id: string;
+  onChange: (categorySelections: { [categoryId: string]: boolean }) => void;
+  style: React.CSSProperties;
+}
+export const CategoryFilterControl: React.ComponentType<CategoryFilterControlProps>;
+/* End of components exported by CategoryFilterControl.js */
+
+/* Start of components exported by Badge.js */
+export interface BadgeProps {
+  children: React.ReactNode;
+  level?: "error" | "info" | "success" | "warning";
+  tooltip: string;
+}
+export const Badge: React.ComponentType<BadgeProps>;
+/* End of components exported by Badge.js */
+
+/* Start of components exported by Checkbox.js */
+export interface CheckboxProps {
+  checked: boolean;
+  disabled?: boolean;
+  id: string;
+  label: string;
+  onChange: (isChecked: boolean) => void;
+}
+
+export const Checkbox: React.ComponentType<CheckboxProps>;
+/* End of components exported by Checkbox.js */
+
+/* Start of components exported by Combobox.js */
+export interface ComboboxOption {
+  label: string;
+}
+export interface ComboboxProps {
+  id?: string;
+  onChange: (value: string) => void;
+  onSelect: (option: ComboboxOption) => void;
+  options: ComboboxOption[];
+  placeholder?: string;
+  renderOption: (option: ComboboxOption) => React.ReactNode;
+  value: string;
+  width?: string;
+}
+export const Combobox: React.ComponentType<ComboboxProps>;
+/* End of components exported by Combobox.js */
+
+/* Start of components exported by Grid.js */
+export interface GridColumnRenderer<RowDatum, CellDatum> {
   (
     rowDatum: RowDatum,
     columnKey: string,
@@ -10,24 +109,27 @@ export interface ColumnRenderer<RowDatum, CellDatum> {
   ): React.ReactNode;
 }
 
-export interface GridPropsColumn<RowDatum, CellData> {
+export interface GridColumn<RowDatum, CellDatum> {
   heading?: string;
   key: string;
   isRowHeader?: boolean;
   isSortable?: boolean;
   minWidth?: number;
   tooltip?: string;
-  render: ColumnRenderer<RowDatum, CellData>;
+  render: GridColumnRenderer<RowDatum, CellDatum>;
 }
-export interface GridProps<RowDatum, CellData> {
-  columns: GridPropsColumn<RowDatum, CellData>[];
-  cellData?: CellData;
+export interface GridProps<RowDatum, CellDatum> {
+  columns: GridColumn<RowDatum, CellDatum>[];
+  cellData?: CellDatum;
   data: RowDatum[];
   numRowsRendered?: number;
   onHoverRow?: (rowIndex: number) => void;
   onRequestSort?: (columnKey: string) => void;
   onScroll?: FixedSizeListProps["onScroll"];
-  onVisibleRowsChange?: (range: {startIndex: number, stopIndex: number}) => void;
+  onVisibleRowsChange?: (range: {
+    startIndex: number;
+    stopIndex: number;
+  }) => void;
   rowHeight?: number;
   rowKey?: (rowDatum: RowDatum) => string;
   shouldHighlightRow?: (rowDatum: RowDatum) => boolean;
@@ -38,7 +140,90 @@ export interface GridProps<RowDatum, CellData> {
 export class Grid<RowDatum, CellData = {}> extends React.Component<
   GridProps<RowDatum, CellData>
 > {}
+/* End of components exported by Grid.js */
 
+/* Start of components exported by Input.js */
+export const Input: StyledComponent<"input", any, {}, never>;
+/* End of components exported by Input.js */
+
+/* Start of components exported by KeyboardShortcut.js */
+export interface KeyboardShortcutProps {
+  keys: string[];
+  handler: () => void;
+}
+export const KeyboardShortcut: React.ComponentType<KeyboardShortcutProps>;
+/* End of components exported by KeyboardShortcut.js */
+
+/* Start of components exported by Link.js */
+export const Link: StyledComponent<"a", any, {}, never>;
+export const ExternalLink: ThemedStyledFunction<
+  "a",
+  any,
+  {
+    rel: "noopener noreferrer";
+    target: "_blank";
+  },
+  "target" | "rel"
+>;
+/* End of components exported by Link.js */
+
+/* Start of components exported by List.js */
+export const List: StyledComponent<"ul", any, {}, never>;
+export const ListItem: StyledComponent<"li", any, {}, never>;
+export const OrderedList: StyledComponent<"ol", any, {}, never>;
+/* End of components exported by List.js */
+
+/* Start of components exported by Modal.js */
+export interface ModalProps {
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  id?: string;
+  onRequestClose: React.MouseEventHandler;
+  size: "small" | "medium" | "large";
+  title: string;
+}
+export const Modal: React.ComponentType<ModalProps>;
+/* End of components exported by Modal.js */
+
+/* Start of components exported by Page.js */
+export const Page: StyledComponent<"div", any, {}, never>;
+export interface PageHeadingProps {
+  className?: string;
+  renderPageControl?: () => React.ReactNode;
+  children: React.ReactNode;
+}
+export const PageHeading: React.ComponentType<PageHeadingProps>;
+/* End of components exported by Page.js */
+
+/* Start of components exported by Searchbox.js */
+interface SearchboxItem<Value> {
+  label: string;
+  value: Value;
+}
+
+export interface SearchboxProps<Value> {
+  fetchSearchResults: (query: string) => Promise<SearchboxItem<Value>[]>;
+  id?: string;
+  onSelect: (itemValue: Value, item: SearchboxItem<Value>) => void;
+  placeholder?: string;
+  width?: number;
+}
+
+export class Searchbox<Value> extends React.Component<
+  SearchboxProps<Value>
+> {}
+/* End of components exported by Searchbox.js */
+
+/* Start of components exported by SearchInput.js */
+export interface SearchInputProps {
+  placeholder?: string;
+  onChange: React.ChangeEventHandler;
+  value?: string;
+}
+export const SearchInput: React.ComponentType<SearchInputProps>;
+/* End of components exported by SearchInput.js */
+
+/* Start of components exported by SegmentedControl.js */
 interface Option<OptionValue extends boolean | number | string> {
   disabled?: boolean;
   label?: string;
@@ -60,33 +245,45 @@ export interface SegmentedControlProps<
 export class SegmentedControl<
   OptionValue extends boolean | number | string
 > extends React.Component<SegmentedControlProps<OptionValue>> {}
+/* End of components exported by SegmentedControl.js */
 
-export interface CheckboxProps {
-  checked: boolean;
-  disabled?: boolean;
+/* Start of components exported by Select.js */
+export const Select: StyledComponent<"select", any, {}, never>;
+/* End of components exported by Select.js */
+
+/* Start of components exported by Table.js */
+export const BaseTable: StyledComponent<"table", any, {}, never>;
+/* End of components exported by Table.js */
+
+/* Start of components exported by Tabs.js */
+export interface Tab {
   id: string;
   label: string;
-  onChange: (isChecked: boolean) => void;
+  render: () => React.ReactNode;
 }
-
-export class Checkbox extends React.Component<CheckboxProps> {}
-
-export const Link: StyledComponent<"a", any, {}, never>;
-
-interface SearchBoxItem<Value> {
-  label: string;
-  value: Value;
+export interface TabsProps {
+  activeTabId?: string;
+  tabs: Tab[];
+  onChange: (tabId: string) => void;
 }
+export const Tabs: React.ComponentType<TabsProps>;
+/* End of components exported by Tabs.js */
 
-export interface SearchboxProps<Value, Item extends SearchBoxItem<Value>> {
-  fetchSearchResults: (query: string) => Promise<Item[]>;
-  id?: string;
-  onSelect: (itemValue: Value, item: Item) => void;
-  placeholder?: string;
-  width?: number;
+/* Start of components exported by DefaultTooltip.js */
+export interface DefaultTooltipProps {
+  tooltip: string;
 }
+export const DefaultTooltip: React.ComponentType<DefaultTooltipProps>;
+/* End of components exported by DefaultTooltip.js */
 
-export class Searchbox<
-  Value,
-  Item extends SearchBoxItem<Value> = SearchBoxItem<Value>
-> extends React.Component<SearchboxProps<Value, Item>> {}
+/* Start of components exported by TooltipAnchor.js */
+export interface TooltipAnchorProps {
+  children: React.ReactNode;
+  tooltipComponent?: React.ElementType;
+}
+export const TooltipAnchor: React.ComponentType<TooltipAnchorProps>;
+/* End of components exported by TooltipAnchor.js */
+
+/* Start of components exported by TooltipHint.js */
+export const TooltipHint: StyledComponent<"span", any, {}, never>;
+/* End of components exported by TooltipHint.js */

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -66,7 +66,7 @@ export const CategoryFilterControl: React.ComponentType<CategoryFilterControlPro
 export interface BadgeProps {
   children: React.ReactNode;
   level?: "error" | "info" | "success" | "warning";
-  tooltip: string;
+  tooltip?: string;
 }
 export const Badge: React.ComponentType<BadgeProps>;
 /* End of components exported by Badge.js */
@@ -87,17 +87,19 @@ export const Checkbox: React.ComponentType<CheckboxProps>;
 export interface ComboboxOption {
   label: string;
 }
-export interface ComboboxProps {
+export interface ComboboxProps<Option extends ComboboxOption> {
   id?: string;
   onChange: (value: string) => void;
-  onSelect: (option: ComboboxOption) => void;
-  options: ComboboxOption[];
+  onSelect: (option: Option) => void;
+  options: Option[];
   placeholder?: string;
-  renderOption: (option: ComboboxOption) => React.ReactNode;
+  renderOption: (option: Option) => React.ReactNode;
   value: string;
   width?: string;
 }
-export const Combobox: React.ComponentType<ComboboxProps>;
+export class Combobox<Option extends ComboboxOption = ComboboxOption> extends React.Component<
+  ComboboxProps<Option>
+> {}
 /* End of components exported by Combobox.js */
 
 /* Start of components exported by Grid.js */
@@ -217,7 +219,7 @@ export class Searchbox<Value> extends React.Component<
 /* Start of components exported by SearchInput.js */
 export interface SearchInputProps {
   placeholder?: string;
-  onChange: React.ChangeEventHandler;
+  onChange: (value: string) => void;
   value?: string;
 }
 export const SearchInput: React.ComponentType<SearchInputProps>;


### PR DESCRIPTION
- Add TypeScript definitions for some of `@gnomad/ui` components.
- Add step to build command to copy type definition, which is in `src` to `lib`, which is the directory that will be published to npm.