### PR TITLE
Fix Rollup build of classification selector component

### DIFF
--- a/packages/classification-selector/CHANGELOG.md
+++ b/packages/classification-selector/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changes
+
+## Version 0.1.1 - August 10, 2020
+
+- Fix bug in Rollup build.
+
+## Version 0.1.0 - July 1, 2020
+
+- Initial version

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnomad/classification-selector",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "files": ["lib"],

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
+  "files": ["lib"],
   "scripts": {
     "jest": "jest --coverage",
     "jest:watch": "jest --watch",

--- a/packages/classification-selector/rollup.config.js
+++ b/packages/classification-selector/rollup.config.js
@@ -5,7 +5,7 @@ import pkg from './package.json'
 
 const extensions = ['.tsx', '.ts', '.js', '.jsx', '.es6', '.es', '.mjs']
 
-const external = Object.keys(pkg.dependencies)
+const external = [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies)]
 
 export default {
   input: 'src/index.ts',


### PR DESCRIPTION
Remove `react` and `react-dom` (both are peer dependencies) from being bundled in the build because otherwise, React will complain about having multiple copies of itself at run time in the consumer. 