### PR TITLE
Make visual view of hierarchical classifications match their structures

### DIFF
--- a/packages/classification-selector/cypress/integration/classificationViewer.spec.js
+++ b/packages/classification-selector/cypress/integration/classificationViewer.spec.js
@@ -1,7 +1,5 @@
 const {
   classificationTreeItemCypressDataAttr,
-  levelSelectorCypressDataAttr,
-  levelSelectorItemCypressDataAttr,
   selectedItemsContainerCypressDataAttr,
   numFilteredItemsCypressDataAttr,
   categoryTreeItemCypressDataAttr,
@@ -73,105 +71,50 @@ describe('Hierarchical classification', () => {
   beforeEach(() => {
     cy.visit('?path=/story/classification-viewer--hierarchical-classification')
   })
-  it('Select a single category at level 1', () => {
+  it('Progressively expand and select single categories', () => {
     cy.getIframeBody().within(() => {
       cy.get(attr(classificationTreeItemCypressDataAttr))
         .as('classification')
         .contains('hierarchical classification')
         .click()
-      cy.get('@classification').contains('category 1-1--1 (2)').as('target-category')
+      cy.get('@classification').contains('category 1-1--1 (2)')
       cy.get('@classification').contains('category 1-1--2 (7)')
       cy.get('@classification').contains('category 2-1--1 (1)')
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('10')
 
-      cy.get('@target-category').click()
-
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('2')
-      cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
-        cy.contains('item a')
-        cy.contains('item g')
-      })
-    })
-  })
-
-  it('Select a single category at level 2', () => {
-    cy.getIframeBody().within(() => {
-      cy.get(attr(classificationTreeItemCypressDataAttr))
-        .as('classification')
-        .contains('hierarchical classification')
-        .click()
-      cy.get(attr(levelSelectorCypressDataAttr)).click()
-      cy.get(attr(levelSelectorItemCypressDataAttr)).contains('2').click()
-      cy.get('@classification').contains('category 1-1--1 (2)')
-      cy.get('@classification').contains('category 1-2--1 (2)').as('target-category-1')
-      cy.get('@classification').contains('category 1-2--2 (2)')
-      cy.get('@classification').contains('category 1-2--3 (3)').as('target-category-2')
-      cy.get('@classification').contains('category 2-2--1 (1)')
-
-      cy.get('@target-category-1').click()
-
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('2')
+      cy.get('@classification').contains('category 1-1--2 (7)').click()
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('7')
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
         cy.contains('item b')
+        cy.contains('item c')
+        cy.contains('item d')
+        cy.contains('item e')
         cy.contains('item h')
+        cy.contains('item i')
+        cy.contains('item j')
       })
 
-      cy.get('@target-category-2').click()
-
+      cy.get('@classification').contains('category 1-2--3 (3)').click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
         cy.contains('item d')
         cy.contains('item e')
         cy.contains('item j')
       })
-    })
-  })
 
-  it('Select a single category at level 3', () => {
-    cy.getIframeBody().within(() => {
-      cy.get(attr(classificationTreeItemCypressDataAttr))
-        .as('classification')
-        .contains('hierarchical classification')
-        .click()
-      cy.get(attr(levelSelectorCypressDataAttr)).click()
-      cy.get(attr(levelSelectorItemCypressDataAttr)).contains('3').click()
-      cy.get('@classification').contains('category 1-1--1 (2)')
-      cy.get('@classification').contains('category 1-2--1 (2)')
-      cy.get('@classification').contains('category 1-2--2 (2)')
-      cy.get('@classification').contains('category 1-3--1 (2)')
-      cy.get('@classification').contains('category 1-3--2 (1)')
-      cy.get('@classification').contains('category 2-3--2 (1)').as('target-category')
-
-      cy.get('@target-category').click()
-
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('1')
-      cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
-        cy.contains('item f')
-      })
-    })
-  })
-
-  it('Select a single category at level 4', () => {
-    cy.getIframeBody().within(() => {
-      cy.get(attr(classificationTreeItemCypressDataAttr))
-        .as('classification')
-        .contains('hierarchical classification')
-        .click()
-      cy.get(attr(levelSelectorCypressDataAttr)).click()
-      cy.get(attr(levelSelectorItemCypressDataAttr)).contains('4').click()
-      cy.get('@classification').contains('category 1-1--1 (2)').as('target-category')
-      cy.get('@classification').contains('category 1-2--1 (2)')
-      cy.get('@classification').contains('category 1-2--2 (2)')
-      cy.get('@classification').contains('category 1-3--1 (2)')
-      cy.get('@classification').contains('category 1-3--2 (1)')
-      cy.get('@classification').contains('category 2-4--1 (1)')
-
-      cy.get('@target-category').click()
-
+      cy.get('@classification').contains('category 1-3--1 (2)').click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('2')
+
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
-        cy.contains('item a')
-        cy.contains('item g')
+        cy.contains('item d')
+        cy.contains('item j')
       })
+
+      cy.get('@classification').contains('category 1-2--3 (3)').click()
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
+
+      cy.get('@classification').contains('category 1-1--2 (7)').click()
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('7')
     })
   })
 
@@ -182,17 +125,11 @@ describe('Hierarchical classification', () => {
         .as('classification')
         .contains('hierarchical classification')
         .click()
-      cy.get(attr(levelSelectorCypressDataAttr)).click()
-      cy.get(attr(levelSelectorItemCypressDataAttr)).contains('2').click()
-      cy.get('@classification').contains('category 1-1--1 (2)')
-      cy.get('@classification').contains('category 1-2--1 (2)').as('target-category-1')
-      cy.get('@classification').contains('category 1-2--2 (2)')
-      cy.get('@classification').contains('category 1-2--3 (3)').as('target-category-2')
-      cy.get('@classification').contains('category 2-2--1 (1)')
 
-      cy.get('@target-category-1').click()
+      cy.get('@classification').contains('category 1-1--2 (7)').click()
+      cy.get('@classification').contains('category 1-2--1 (2)').click()
       cy.get('@body').type('{meta}', { release: false })
-      cy.get('@target-category-2').click()
+      cy.get('@classification').contains('category 1-2--3 (3)').click()
 
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('5')
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
@@ -244,10 +181,8 @@ describe('multiple classifications', () => {
 })
 
 describe('select all/none', () => {
-  beforeEach(() => {
+  it('expanding a simple classification, then selecting a category, then "select all" then "select none" should show the same result', () => {
     cy.visit('?path=/story/classification-viewer--select-all-or-none-simple-classification')
-  })
-  it.only('expanding a classification, then selecting a category, then "select all" then "select none" should show the same result', () => {
     cy.getIframeBody().within(() => {
       cy.get(attr(classificationTreeItemCypressDataAttr))
         .as('classification')
@@ -258,6 +193,30 @@ describe('select all/none', () => {
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
       cy.get(attr(selectNoneCypressDataAttr)).click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
+    })
+  })
+
+  it('clicking "select all" while a hierarchical classification is selected should expand all categories in that classification', () => {
+    cy.visit(
+      '?path=/story/classification-viewer--select-all-or-select-none-hierarchical-classification'
+    )
+    cy.getIframeBody().within(() => {
+      cy.get(attr(classificationTreeItemCypressDataAttr))
+        .as('classification')
+        .contains('hierarchical classification')
+        .click()
+      cy.get(attr(selectAllCypressDataAttr)).click()
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-1--1').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-1--2').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-2--1').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-2--2').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-2--3').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-3--1').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 1-3--2').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 2-1--1').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 2-2--1').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 2-3--2').should('be.visible')
+      cy.get(attr(categoryTreeItemCypressDataAttr)).contains('category 2-4--1').should('be.visible')
     })
   })
 })

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnomad/classification-selector",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "files": ["lib"],

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -4,6 +4,9 @@
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "files": ["lib"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "jest": "jest --coverage",
     "jest:watch": "jest --watch",

--- a/packages/classification-selector/src/ClassificationViewer.tsx
+++ b/packages/classification-selector/src/ClassificationViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import TreeView from '@material-ui/lab/TreeView'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import ChevronRightIcon from '@material-ui/icons/ChevronRight'
@@ -6,24 +6,21 @@ import TreeItem from '@material-ui/lab/TreeItem'
 import Box from '@material-ui/core/Box'
 import Button from '@material-ui/core/Button'
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles'
-import InputLabel from '@material-ui/core/InputLabel'
-import MenuItem from '@material-ui/core/MenuItem'
-import FormControl from '@material-ui/core/FormControl'
-import Select from '@material-ui/core/Select'
-import _range from 'lodash/range'
 import { StandardLonghandProperties } from 'csstype'
 import FiberManualRecordIcon from '@material-ui/icons/FiberManualRecord'
 import ScopedCssBaseline from '@material-ui/core/ScopedCssBaseline'
 import { Classification, ClassificationType } from './types'
-import { getDisplayedHierarchicalClassification, getDisplayedSimpleClassification } from './Utils'
+import {
+  getDisplayedHierarchicalClassification,
+  getDisplayedSimpleClassification,
+  DisplayedHierarchicalCategory,
+} from './Utils'
 import useInternalState from './useClassificationSelectorState'
 import 'fontsource-roboto'
 
 const {
   categoryTreeItemCypressDataAttr,
   classificationTreeItemCypressDataAttr,
-  levelSelectorCypressDataAttr,
-  levelSelectorItemCypressDataAttr,
   selectAllCypressDataAttr,
   selectNoneCypressDataAttr,
 } = require('./cypressTestDataAttrs.json')
@@ -43,6 +40,33 @@ const useMaterialStyles = makeStyles<Theme, MakeStyleProps>(theme =>
   })
 )
 
+const displayedHierarchicalCategoryToReactElem = (category: DisplayedHierarchicalCategory) => {
+  const { nodeId } = category
+  const displayedLabel = `${category.name} (${category.itemCount})`
+  if (category.hasChildren === true) {
+    const children = category.children.map(elem => displayedHierarchicalCategoryToReactElem(elem))
+    return (
+      <TreeItem
+        nodeId={nodeId}
+        key={nodeId}
+        data-cy={categoryTreeItemCypressDataAttr}
+        label={displayedLabel}
+      >
+        {children}
+      </TreeItem>
+    )
+  }
+  return (
+    <TreeItem
+      nodeId={nodeId}
+      key={nodeId}
+      data-cy={categoryTreeItemCypressDataAttr}
+      label={displayedLabel}
+      icon={<FiberManualRecordIcon style={{ color: category.color }} />}
+    />
+  )
+}
+
 type ExternallyControlledState = ReturnType<typeof useInternalState>
 
 export interface Props<Item> {
@@ -51,24 +75,22 @@ export interface Props<Item> {
   categoryListMaxHeight?: MakeStyleProps['categoryListMaxHeight']
   selected: ExternallyControlledState['selected']
   setSelected: ExternallyControlledState['setSelected']
-  hierarchicalLevels: ExternallyControlledState['hierarchicalLevels']
-  setHierarchicalLevel: ExternallyControlledState['setHierarchicalLevel']
+  expanded: ExternallyControlledState['expanded']
+  setExpanded: ExternallyControlledState['setExpanded']
   clearSelectedCategories: () => void
   selectAllVisibleCategories: () => void
 }
 
 function ClassificationViewer<Item>({
+  expanded,
+  setExpanded,
   selected,
   setSelected,
-  hierarchicalLevels,
-  setHierarchicalLevel,
   classifications,
   categoryListMaxHeight,
   clearSelectedCategories,
   selectAllVisibleCategories,
 }: Props<Item>) {
-  const [expanded, setExpanded] = useState<string[]>([])
-
   const handleToggle = (_e: React.ChangeEvent<unknown>, nodeIds: string[]) => setExpanded(nodeIds)
   const handleSelect = (_e: React.ChangeEvent<unknown>, nodeIds: string[]) => setSelected(nodeIds)
 
@@ -104,58 +126,22 @@ function ClassificationViewer<Item>({
         </TreeItem>
       )
     } else {
-      const hierarchicalLevel = hierarchicalLevels[classification.name]
       const {
         name: classificationName,
         nodeId: classificationNodeId,
-        maxHierarchicalLevel,
         categories,
-      } = getDisplayedHierarchicalClassification({
-        classification,
-        hierarchicalLevel,
-      })
-      const categoryElems = categories.map(({ nodeId, displayedLabel, color }) => (
-        <TreeItem
-          nodeId={nodeId}
-          key={nodeId}
-          data-cy={categoryTreeItemCypressDataAttr}
-          label={displayedLabel}
-          icon={<FiberManualRecordIcon style={{ color }} />}
-        />
-      ))
-      const dropdownLabelId = `label-classification-${classificationName}`
-      const dropdownItems = _range(maxHierarchicalLevel).map(level => (
-        <MenuItem value={level + 1} key={level} data-cy={levelSelectorItemCypressDataAttr}>
-          {level + 1}
-        </MenuItem>
-      ))
+      } = getDisplayedHierarchicalClassification(classification)
+      const categoryElems = categories.map(category =>
+        displayedHierarchicalCategoryToReactElem(category)
+      )
+
       result = (
         <TreeItem
           key={classificationNodeId}
           data-cy={classificationTreeItemCypressDataAttr}
           nodeId={classificationNodeId}
           classes={{ group: categoryListClassName }}
-          label={
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-              <Box>{classificationName}</Box>
-              <FormControl
-                className={materialClasses.levelSelector}
-                onClick={e => e.stopPropagation()}
-              >
-                <InputLabel id={dropdownLabelId}>Level</InputLabel>
-                <Select
-                  labelId={dropdownLabelId}
-                  value={hierarchicalLevel}
-                  data-cy={levelSelectorCypressDataAttr}
-                  onChange={event =>
-                    setHierarchicalLevel(classification.name, event.target.value as number)
-                  }
-                >
-                  {dropdownItems}
-                </Select>
-              </FormControl>
-            </Box>
-          }
+          label={classificationName}
         >
           {categoryElems}
         </TreeItem>

--- a/packages/classification-selector/src/TestWrapper.tsx
+++ b/packages/classification-selector/src/TestWrapper.tsx
@@ -24,8 +24,8 @@ function TestWrapper<Item extends TestItem>({ items, classifications }: Props<It
     filteredItems,
     selected,
     setSelected,
-    hierarchicalLevels,
-    setHierarchicalLevel,
+    expanded,
+    setExpanded,
     clearSelectedCategories,
     selectAllVisibleCategories,
   } = useInternalState({ items, classifications })
@@ -46,8 +46,8 @@ function TestWrapper<Item extends TestItem>({ items, classifications }: Props<It
               classifications={classifications}
               selected={selected}
               setSelected={setSelected}
-              hierarchicalLevels={hierarchicalLevels}
-              setHierarchicalLevel={setHierarchicalLevel}
+              expanded={expanded}
+              setExpanded={setExpanded}
             />
           </Grid>
           <Grid item xs={6}>

--- a/packages/classification-selector/src/__tests__/Utils.js
+++ b/packages/classification-selector/src/__tests__/Utils.js
@@ -51,6 +51,63 @@ describe('simple classification node id generator/parser', () => {
 })
 
 describe('getDisplayedHierarchicalCategories', () => {
+  test('Non-terminal category', () => {
+    const classification = {
+      name: 'hierarchical classification',
+      type: ClassificationType.Hierarchical,
+      categories: [
+        { path: ['category 1-1--1'], itemCount: 2, color: '#7fc97f' },
+        { path: ['category 1-1--1', 'category 1-1--2'], itemCount: 2, color: '#00ff00' },
+        {
+          path: ['category 1-1--1', 'category 1-1--2', 'category 1-1--3'],
+          itemCount: 1,
+          color: '#beaed4',
+        },
+      ],
+    }
+    const expected = [
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 1-1--1'],
+        }),
+        name: 'category 1-1--1',
+        itemCount: 5,
+        hasChildren: true,
+        children: [
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 1-1--1', 'category 1-1--2'],
+            }),
+            name: 'category 1-1--2',
+            itemCount: 3,
+            hasChildren: true,
+            children: [
+              {
+                nodeId: generateNodeId({
+                  type: 'category',
+                  classificationType: ClassificationType.Hierarchical,
+                  classification: 'hierarchical classification',
+                  path: ['category 1-1--1', 'category 1-1--2', 'category 1-1--3'],
+                }),
+                name: 'category 1-1--3',
+                itemCount: 1,
+                hasChildren: false,
+                color: '#beaed4',
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
+    expect(actual).toEqual(expected)
+  })
   test('One category of depth one', () => {
     const classification = {
       name: 'hierarchical classification',
@@ -74,7 +131,7 @@ describe('getDisplayedHierarchicalCategories', () => {
     const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
     expect(actual).toEqual(expected)
   })
-  test('Only one deep path', () => {
+  test('One single deep path', () => {
     const classification = {
       name: 'hierarchical classification',
       type: ClassificationType.Hierarchical,
@@ -218,8 +275,13 @@ describe('getDisplayedHierarchicalCategories', () => {
           color: '#386cb0',
         },
         {
-          path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2', 'category 2-4--1'],
+          path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2'],
           itemCount: 1,
+          color: '#f0027f',
+        },
+        {
+          path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2', 'category 2-4--1'],
+          itemCount: 2,
           color: '#f0027f',
         },
       ],
@@ -320,7 +382,7 @@ describe('getDisplayedHierarchicalCategories', () => {
           path: ['category 2-1--1'],
         }),
         name: 'category 2-1--1',
-        itemCount: 1,
+        itemCount: 3,
         hasChildren: true,
         children: [
           {
@@ -331,7 +393,7 @@ describe('getDisplayedHierarchicalCategories', () => {
               path: ['category 2-1--1', 'category 2-2--1'],
             }),
             name: 'category 2-2--1',
-            itemCount: 1,
+            itemCount: 3,
             hasChildren: true,
             children: [
               {
@@ -342,7 +404,7 @@ describe('getDisplayedHierarchicalCategories', () => {
                   path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2'],
                 }),
                 name: 'category 2-3--2',
-                itemCount: 1,
+                itemCount: 3,
                 hasChildren: true,
                 children: [
                   {
@@ -358,7 +420,7 @@ describe('getDisplayedHierarchicalCategories', () => {
                       ],
                     }),
                     name: 'category 2-4--1',
-                    itemCount: 1,
+                    itemCount: 2,
                     hasChildren: false,
                     color: '#f0027f',
                   },

--- a/packages/classification-selector/src/__tests__/Utils.js
+++ b/packages/classification-selector/src/__tests__/Utils.js
@@ -1,7 +1,7 @@
-import { generateNodeId, parseNodeId } from '../Utils'
+import { generateNodeId, parseNodeId, getDisplayedHierarchicalCategories } from '../Utils'
 import { ClassificationType } from '../types'
 
-describe('node id generators and parsers', () => {
+describe('simple classification node id generator/parser', () => {
   test('simple classification at category level', () => {
     const inputs = {
       type: 'category',
@@ -19,13 +19,24 @@ describe('node id generators and parsers', () => {
     }
     expect(parseNodeId(generateNodeId(inputs))).toEqual(inputs)
   })
-  test('hierarchical classification at category level', () => {
+})
+
+describe('simple classification node id generator/parser', () => {
+  test('hierarchical classification at category level 1', () => {
     const inputs = {
       type: 'category',
       classificationType: ClassificationType.Hierarchical,
       classification: 'hierarchical-classification',
-      category: 'category 1-2--1',
-      level: 2,
+      path: ['category 1-1--1'],
+    }
+    expect(parseNodeId(generateNodeId(inputs))).toEqual(inputs)
+  })
+  test('hierarchical classification at category level 2', () => {
+    const inputs = {
+      type: 'category',
+      classificationType: ClassificationType.Hierarchical,
+      classification: 'hierarchical-classification',
+      path: ['category 1-1--1', 'category 1-1--2'],
     }
     expect(parseNodeId(generateNodeId(inputs))).toEqual(inputs)
   })
@@ -36,5 +47,329 @@ describe('node id generators and parsers', () => {
       classification: 'hierarchical-classification',
     }
     expect(parseNodeId(generateNodeId(inputs))).toEqual(inputs)
+  })
+})
+
+describe('getDisplayedHierarchicalCategories', () => {
+  test('One category of depth one', () => {
+    const classification = {
+      name: 'hierarchical classification',
+      type: ClassificationType.Hierarchical,
+      categories: [{ path: ['category 2-1--1'], itemCount: 1, color: '#f0027f' }],
+    }
+    const expected = [
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 2-1--1'],
+        }),
+        name: 'category 2-1--1',
+        itemCount: 1,
+        hasChildren: false,
+        color: '#f0027f',
+      },
+    ]
+    const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
+    expect(actual).toEqual(expected)
+  })
+  test('Only one deep path', () => {
+    const classification = {
+      name: 'hierarchical classification',
+      type: ClassificationType.Hierarchical,
+      categories: [
+        {
+          path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2', 'category 2-4--1'],
+          itemCount: 1,
+          color: '#f0027f',
+        },
+      ],
+    }
+    const expected = [
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 2-1--1'],
+        }),
+        name: 'category 2-1--1',
+        itemCount: 1,
+        hasChildren: true,
+        children: [
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 2-1--1', 'category 2-2--1'],
+            }),
+            name: 'category 2-2--1',
+            itemCount: 1,
+            hasChildren: true,
+            children: [
+              {
+                nodeId: generateNodeId({
+                  type: 'category',
+                  classificationType: ClassificationType.Hierarchical,
+                  classification: 'hierarchical classification',
+                  path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2'],
+                }),
+                name: 'category 2-3--2',
+                itemCount: 1,
+                hasChildren: true,
+                children: [
+                  {
+                    nodeId: generateNodeId({
+                      type: 'category',
+                      classificationType: ClassificationType.Hierarchical,
+                      classification: 'hierarchical classification',
+                      path: [
+                        'category 2-1--1',
+                        'category 2-2--1',
+                        'category 2-3--2',
+                        'category 2-4--1',
+                      ],
+                    }),
+                    name: 'category 2-4--1',
+                    itemCount: 1,
+                    hasChildren: false,
+                    color: '#f0027f',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
+    expect(actual).toEqual(expected)
+  })
+
+  test('Multiple one-deep paths', () => {
+    const classification = {
+      name: 'hierarchical classification',
+      type: ClassificationType.Hierarchical,
+      categories: [
+        { path: ['category 1-1--1'], itemCount: 2, color: '#7fc97f' },
+        { path: ['category 1-1--2'], itemCount: 7, color: '#fdc086' },
+        { path: ['category 2-1--1'], itemCount: 1, color: '#f0027f' },
+      ],
+    }
+    const expected = [
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 1-1--1'],
+        }),
+        name: 'category 1-1--1',
+        itemCount: 2,
+        hasChildren: false,
+        color: '#7fc97f',
+      },
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 1-1--2'],
+        }),
+        name: 'category 1-1--2',
+        itemCount: 7,
+        hasChildren: false,
+        color: '#fdc086',
+      },
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 2-1--1'],
+        }),
+        name: 'category 2-1--1',
+        itemCount: 1,
+        hasChildren: false,
+        color: '#f0027f',
+      },
+    ]
+    const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
+    expect(actual).toEqual(expected)
+  })
+  test('General case', () => {
+    const classification = {
+      name: 'hierarchical classification',
+      type: ClassificationType.Hierarchical,
+      categories: [
+        { path: ['category 1-1--1'], itemCount: 2, color: '#7fc97f' },
+        { path: ['category 1-1--2', 'category 1-2--1'], itemCount: 2, color: '#beaed4' },
+        { path: ['category 1-1--2', 'category 1-2--2'], itemCount: 2, color: '#fdc086' },
+        {
+          path: ['category 1-1--2', 'category 1-2--3', 'category 1-3--1'],
+          itemCount: 2,
+          color: '#ffff99',
+        },
+        {
+          path: ['category 1-1--2', 'category 1-2--3', 'category 1-3--2'],
+          itemCount: 1,
+          color: '#386cb0',
+        },
+        {
+          path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2', 'category 2-4--1'],
+          itemCount: 1,
+          color: '#f0027f',
+        },
+      ],
+    }
+
+    const expected = [
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 1-1--1'],
+        }),
+        name: 'category 1-1--1',
+        itemCount: 2,
+        hasChildren: false,
+        color: '#7fc97f',
+      },
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 1-1--2'],
+        }),
+        name: 'category 1-1--2',
+        itemCount: 7,
+        hasChildren: true,
+        children: [
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 1-1--2', 'category 1-2--1'],
+            }),
+            name: 'category 1-2--1',
+            itemCount: 2,
+            hasChildren: false,
+            color: '#beaed4',
+          },
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 1-1--2', 'category 1-2--2'],
+            }),
+            name: 'category 1-2--2',
+            itemCount: 2,
+            hasChildren: false,
+            color: '#fdc086',
+          },
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 1-1--2', 'category 1-2--3'],
+            }),
+            name: 'category 1-2--3',
+            itemCount: 3,
+            hasChildren: true,
+            children: [
+              {
+                nodeId: generateNodeId({
+                  type: 'category',
+                  classificationType: ClassificationType.Hierarchical,
+                  classification: 'hierarchical classification',
+                  path: ['category 1-1--2', 'category 1-2--3', 'category 1-3--1'],
+                }),
+                name: 'category 1-3--1',
+                itemCount: 2,
+                hasChildren: false,
+                color: '#ffff99',
+              },
+              {
+                nodeId: generateNodeId({
+                  type: 'category',
+                  classificationType: ClassificationType.Hierarchical,
+                  classification: 'hierarchical classification',
+                  path: ['category 1-1--2', 'category 1-2--3', 'category 1-3--2'],
+                }),
+                name: 'category 1-3--2',
+                itemCount: 1,
+                hasChildren: false,
+                color: '#386cb0',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        nodeId: generateNodeId({
+          type: 'category',
+          classificationType: ClassificationType.Hierarchical,
+          classification: 'hierarchical classification',
+          path: ['category 2-1--1'],
+        }),
+        name: 'category 2-1--1',
+        itemCount: 1,
+        hasChildren: true,
+        children: [
+          {
+            nodeId: generateNodeId({
+              type: 'category',
+              classificationType: ClassificationType.Hierarchical,
+              classification: 'hierarchical classification',
+              path: ['category 2-1--1', 'category 2-2--1'],
+            }),
+            name: 'category 2-2--1',
+            itemCount: 1,
+            hasChildren: true,
+            children: [
+              {
+                nodeId: generateNodeId({
+                  type: 'category',
+                  classificationType: ClassificationType.Hierarchical,
+                  classification: 'hierarchical classification',
+                  path: ['category 2-1--1', 'category 2-2--1', 'category 2-3--2'],
+                }),
+                name: 'category 2-3--2',
+                itemCount: 1,
+                hasChildren: true,
+                children: [
+                  {
+                    nodeId: generateNodeId({
+                      type: 'category',
+                      classificationType: ClassificationType.Hierarchical,
+                      classification: 'hierarchical classification',
+                      path: [
+                        'category 2-1--1',
+                        'category 2-2--1',
+                        'category 2-3--2',
+                        'category 2-4--1',
+                      ],
+                    }),
+                    name: 'category 2-4--1',
+                    itemCount: 1,
+                    hasChildren: false,
+                    color: '#f0027f',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const { categoriesAsList: actual } = getDisplayedHierarchicalCategories(classification)
+    expect(actual).toEqual(expected)
   })
 })

--- a/packages/classification-selector/src/cypressTestDataAttrs.json
+++ b/packages/classification-selector/src/cypressTestDataAttrs.json
@@ -2,8 +2,6 @@
   "categoryTreeItemCypressDataAttr": "category-tree-item",
   "classificationTreeItemCypressDataAttr": "classification-tree-item",
   "selectedItemsContainerCypressDataAttr": "selected-items",
-  "levelSelectorCypressDataAttr": "level-selector",
-  "levelSelectorItemCypressDataAttr": "level-selector-item",
   "numFilteredItemsCypressDataAttr": "num-filtered-items",
   "selectAllCypressDataAttr": "select-all",
   "selectNoneCypressDataAttr": "select-none"

--- a/packages/classification-selector/src/index.stories.js
+++ b/packages/classification-selector/src/index.stories.js
@@ -137,3 +137,7 @@ export const selectAllOrNoneSimpleClassification = () => (
     classifications={[...simpleClassifications]}
   />
 )
+
+export const selectAllOrSelectNoneHierarchicalClassification = () => (
+  <TestWrapper items={items} classifications={hierarchicalClassifications} />
+)


### PR DESCRIPTION
Previously, categories at different levels of a hierarchical classification can only be shown by picking a numerical level from a dropdown list. This PR makes all levels of a hierarchical classification explorable through the Tree View component's expand/collapse feature.