### PR TITLE
Normalize positions to 1 base regions

### DIFF
--- a/packages/identifiers/src/identifiers.js
+++ b/packages/identifiers/src/identifiers.js
@@ -1,41 +1,34 @@
-const REGION_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]([0-9,]+)([-:]([0-9,]+)?)?$/i
-
-export const isRegionId = str => {
-  const match = REGION_ID_REGEX.exec(str)
-  if (!match) {
-    return false
-  }
-
-  const chrom = match[2].toLowerCase()
-  const chromNumber = Number(chrom)
-  if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
-    return false
-  }
-
-  const start = Number(match[3])
-  const end = Number(match[5])
-
-  if (end && end < start) {
-    return false
-  }
-
-  return true
-}
+const REGION_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]([\d,]+)([-:]([\d,]+)?)?$/i
 
 export const normalizeRegionId = regionId => {
-  const parts = regionId.split(/[-:.]/)
-  const chrom = parts[0].toUpperCase().replace(/^CHR/, '')
-  let start = Number(parts[1].replace(/,/g, ''))
-  let end
-
-  if (parts[2]) {
-    end = Number(parts[2].replace(/,/g, ''))
-  } else {
-    end = start + 20
-    start = Math.max(start - 20, 0)
+  const match = REGION_ID_REGEX.exec(regionId)
+  if (!match) {
+    throw new Error('Invalid region ID')
   }
 
-  return `${chrom}-${start}-${end}`
+  const chrom = match[2]
+  const chromNumber = Number(chrom)
+  if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
+    throw new Error('Invalid region ID')
+  }
+
+  const start = Number(match[3].replace(/,/g, ''))
+  const end = match[5] ? Number(match[5].replace(/,/g, '')) : start
+
+  if (end < start) {
+    throw new Error('Invalid region ID')
+  }
+
+  return `${chrom.toUpperCase()}-${start}-${end}`
+}
+
+export const isRegionId = str => {
+  try {
+    normalizeRegionId(str)
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 const VARIANT_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]?((([\d,]+)[-:.]?([acgt]+)[-:.>]([acgt]+))|(([acgt]+)[-:.]?([\d,]+)[-:.]?([acgt]+)))$/i

--- a/packages/identifiers/src/identifiers.spec.js
+++ b/packages/identifiers/src/identifiers.spec.js
@@ -42,16 +42,16 @@ describe('isRegionId', () => {
 
 describe('normalizeRegionId', () => {
   const testCases = [
-    { input: 'chr1-13414', normalized: '1-13394-13434' },
+    { input: 'chr1-13414', normalized: '1-13414-13414' },
     { input: '1-15342343-15342563', normalized: '1-15342343-15342563' },
     { input: '1:15342343-15342563', normalized: '1-15342343-15342563' },
     { input: '1:00042343-00042563', normalized: '1-42343-42563' },
     { input: 'CHR3-12433-19000', normalized: '3-12433-19000' },
-    { input: '3:2592432', normalized: '3-2592412-2592452' },
-    { input: 'chrX-23532-', normalized: 'X-23512-23552' },
-    { input: '2-35324:', normalized: '2-35304-35344' },
+    { input: '3:2592432', normalized: '3-2592432-2592432' },
+    { input: 'chrX-23532-', normalized: 'X-23532-23532' },
+    { input: '2-35324:', normalized: '2-35324-35324' },
     { input: 'y-712321-811232', normalized: 'Y-712321-811232' },
-    { input: '3-10', normalized: '3-0-30' },
+    { input: '3-10', normalized: '3-10-10' },
     { input: '1:55,505,222-55,530,526', normalized: '1-55505222-55530526' },
     { input: 'm.300-320', normalized: 'M-300-320' },
   ]


### PR DESCRIPTION
Previously, positions / regions without an end coordinate were converted to 40 base regions centered on the position. The previous behavior was based on how region search works in the gnomAD browser's region.

Also, similar to #20, `normalizeRegionId` now throws an error if it cannot parse a string. Previously, it was assumed that `normalizeRegionId` would only be called on strings that passed an `isRegionId` test.