### PR TITLE
Add parse region ID / variant ID functions

### DIFF
--- a/packages/identifiers/src/identifiers.js
+++ b/packages/identifiers/src/identifiers.js
@@ -1,30 +1,35 @@
 const REGION_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]([\d,]+)([-:]([\d,]+)?)?$/i
 
-export const normalizeRegionId = regionId => {
+export const parseRegionId = regionId => {
   const match = REGION_ID_REGEX.exec(regionId)
   if (!match) {
     throw new Error('Invalid region ID')
   }
 
-  const chrom = match[2]
+  const chrom = match[2].toUpperCase()
   const chromNumber = Number(chrom)
   if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
     throw new Error('Invalid region ID')
   }
 
   const start = Number(match[3].replace(/,/g, ''))
-  const end = match[5] ? Number(match[5].replace(/,/g, '')) : start
+  const stop = match[5] ? Number(match[5].replace(/,/g, '')) : start
 
-  if (end < start) {
+  if (stop < start) {
     throw new Error('Invalid region ID')
   }
 
-  return `${chrom.toUpperCase()}-${start}-${end}`
+  return { chrom, start, stop }
+}
+
+export const normalizeRegionId = regionId => {
+  const { chrom, start, stop } = parseRegionId(regionId)
+  return `${chrom}-${start}-${stop}`
 }
 
 export const isRegionId = str => {
   try {
-    normalizeRegionId(str)
+    parseRegionId(str)
     return true
   } catch (err) {
     return false
@@ -33,13 +38,13 @@ export const isRegionId = str => {
 
 const VARIANT_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]?((([\d,]+)[-:.]?([acgt]+)[-:.>]([acgt]+))|(([acgt]+)[-:.]?([\d,]+)[-:.]?([acgt]+)))$/i
 
-export const normalizeVariantId = variantId => {
+export const parseVariantId = variantId => {
   const match = VARIANT_ID_REGEX.exec(variantId)
   if (!match) {
     throw new Error('Invalid variant ID')
   }
 
-  const chrom = match[2]
+  const chrom = match[2].toUpperCase()
   const chromNumber = Number(chrom)
   if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
     throw new Error('Invalid variant ID')
@@ -63,12 +68,21 @@ export const normalizeVariantId = variantId => {
   }
   /* eslint-enable prefer-destructuring */
 
-  return `${chrom}-${Number(pos.replace(/,/g, ''))}-${ref}-${alt}`.toUpperCase()
+  pos = Number(pos.replace(/,/g, ''))
+  ref = ref.toUpperCase()
+  alt = alt.toUpperCase()
+
+  return { chrom, pos, ref, alt }
+}
+
+export const normalizeVariantId = variantId => {
+  const { chrom, pos, ref, alt } = parseVariantId(variantId)
+  return `${chrom}-${pos}-${ref}-${alt}`
 }
 
 export const isVariantId = str => {
   try {
-    normalizeVariantId(str)
+    parseVariantId(str)
     return true
   } catch (err) {
     return false

--- a/packages/identifiers/src/identifiers.spec.js
+++ b/packages/identifiers/src/identifiers.spec.js
@@ -1,7 +1,9 @@
 import {
   isRegionId,
+  parseRegionId,
   normalizeRegionId,
   isVariantId,
+  parseVariantId,
   normalizeVariantId,
   isRsId,
 } from './identifiers'
@@ -38,6 +40,36 @@ describe('isRegionId', () => {
   const negativeTestCases = ['chr1-', '5-1243421-a', '3-356788-123245', '54-12432-15440']
 
   test(isRegionId, positiveTestCases, negativeTestCases)
+})
+
+describe('parseRegionId', () => {
+  const testCases = [
+    { input: 'chr1-13414', parsed: { chrom: '1', start: 13414, stop: 13414 } },
+    { input: '1-15342343-15342563', parsed: { chrom: '1', start: 15342343, stop: 15342563 } },
+    { input: '1:15342343-15342563', parsed: { chrom: '1', start: 15342343, stop: 15342563 } },
+    { input: '1:00042343-00042563', parsed: { chrom: '1', start: 42343, stop: 42563 } },
+    { input: 'CHR3-12433-19000', parsed: { chrom: '3', start: 12433, stop: 19000 } },
+    { input: '3:2592432', parsed: { chrom: '3', start: 2592432, stop: 2592432 } },
+    { input: 'chrX-23532-', parsed: { chrom: 'X', start: 23532, stop: 23532 } },
+    { input: '2-35324:', parsed: { chrom: '2', start: 35324, stop: 35324 } },
+    { input: 'y-712321-811232', parsed: { chrom: 'Y', start: 712321, stop: 811232 } },
+    { input: '3-10', parsed: { chrom: '3', start: 10, stop: 10 } },
+    { input: '1:55,505,222-55,530,526', parsed: { chrom: '1', start: 55505222, stop: 55530526 } },
+    { input: 'm.300-320', parsed: { chrom: 'M', start: 300, stop: 320 } },
+  ]
+
+  testCases.forEach(({ input, parsed }) => {
+    it(`should parse ${input} to ${parsed}`, () => {
+      expect(parseRegionId(input)).toStrictEqual(parsed)
+    })
+  })
+
+  it('should throw an error on invalid region IDs', () => {
+    const negativeTestCases = ['chr1-', '5-1243421-a', '3-356788-123245', '54-12432-15440']
+    negativeTestCases.forEach(str => {
+      expect(() => parseRegionId(str)).toThrow('Invalid region ID')
+    })
+  })
 })
 
 describe('normalizeRegionId', () => {
@@ -93,6 +125,49 @@ describe('isVariantId', () => {
   ]
 
   test(isVariantId, positiveTestCases, negativeTestCases)
+})
+
+describe('parseVariantId', () => {
+  const testCases = [
+    { input: 'chr1-13414-a-c', parsed: { chrom: '1', pos: 13414, ref: 'A', alt: 'C' } },
+    { input: 'chr1:13414:a:c', parsed: { chrom: '1', pos: 13414, ref: 'A', alt: 'C' } },
+    { input: '1-15342343-cagc-t', parsed: { chrom: '1', pos: 15342343, ref: 'CAGC', alt: 'T' } },
+    { input: '1-00042343-G-T', parsed: { chrom: '1', pos: 42343, ref: 'G', alt: 'T' } },
+    { input: 'CHR3-12433-A-GATC', parsed: { chrom: '3', pos: 12433, ref: 'A', alt: 'GATC' } },
+    { input: '1-55,516,888-G-GA', parsed: { chrom: '1', pos: 55516888, ref: 'G', alt: 'GA' } },
+    { input: 'm.300-G-A', parsed: { chrom: 'M', pos: 300, ref: 'G', alt: 'A' } },
+    { input: 'm.A3243G', parsed: { chrom: 'M', pos: 3243, ref: 'A', alt: 'G' } },
+    { input: '3-7643T>C', parsed: { chrom: '3', pos: 7643, ref: 'T', alt: 'C' } },
+    { input: 'chr11C308G', parsed: { chrom: '11', pos: 308, ref: 'C', alt: 'G' } },
+    { input: '1G55,516,888GA', parsed: { chrom: '1', pos: 55516888, ref: 'G', alt: 'GA' } },
+  ]
+
+  testCases.forEach(({ input, parsed }) => {
+    it(`should parse ${input} to ${parsed}`, () => {
+      expect(parseVariantId(input)).toStrictEqual(parsed)
+    })
+  })
+
+  it('should throw an error on invalid variant IDs', () => {
+    const negativeTestCases = [
+      'chr1-',
+      'chr2-532434',
+      '5-1243421-a-z',
+      '6-1a1bc-a-gc',
+      'R-1242-A-T',
+      'chrX-23532-cG',
+      'y-712321-a-',
+      'm.B3243C',
+      '4-123A->G',
+      '2A100T100G',
+      '2.100T200A',
+      '1T-100-A-G',
+    ]
+
+    negativeTestCases.forEach(str => {
+      expect(() => parseVariantId(str)).toThrow('Invalid variant ID')
+    })
+  })
 })
 
 describe('normalizeVariantId', () => {


### PR DESCRIPTION
Add `parseVariantId` and `parseRegionId` functions to that return objects with components of IDs (`{ chrom, pos, ref, alt }` and `{ chrom, start, stop }`).

A common pattern in the gnomAD browser is:
```js
const normalizedVariantId = normalizeVariantId(variantId)
let [chrom, pos, ref, alt] = normalizedVariantId.split('-')
pos = Number(pos)
```

These functions would replace that pattern.