### PR TITLE
Prevent segmented control labels from wrapping to multiple lines

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Prevent segmented control labels from wrapping onto multiple lines.
+
 ## Version 1.0.0 - July 1, 2020
 
 Initial release

--- a/packages/ui/src/SegmentedControl.js
+++ b/packages/ui/src/SegmentedControl.js
@@ -29,6 +29,7 @@ const SegmentedControlContainer = styled.span`
     cursor: pointer;
     font-size: 1em;
     line-height: 1.25;
+    white-space: nowrap;
 
     &:first-of-type {
       border-bottom-left-radius: 0.5em;


### PR DESCRIPTION
Currently, when space constrained, segmented control labels may wrap onto multiple lines and overflow the control.

Before
![Screen Shot 2020-09-15 at 11 06 39 AM](https://user-images.githubusercontent.com/1156625/93228884-027ffb00-f744-11ea-96ce-94584f25a1f4.png)

After
![Screen Shot 2020-09-15 at 11 06 47 AM](https://user-images.githubusercontent.com/1156625/93228886-027ffb00-f744-11ea-9a01-cc4b67454e43.png)

