### PR TITLE
Allow each item to belong to multiple categories of a hierarchical classification

### DIFF
--- a/packages/classification-selector/CHANGELOG.md
+++ b/packages/classification-selector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 0.6.0 - September 29, 2020
+
+- Allow an item to belong to multiple categories of a single hierarchical classification.
+
 ## Version 0.1.1 - August 10, 2020
 
 - Fix bug in Rollup build.

--- a/packages/classification-selector/cypress/integration/classificationViewer.spec.js
+++ b/packages/classification-selector/cypress/integration/classificationViewer.spec.js
@@ -78,13 +78,14 @@ describe('Hierarchical classification', () => {
         .contains('hierarchical classification')
         .click()
       cy.get('@classification').contains('category 1-1--1 (2)')
-      cy.get('@classification').contains('category 1-1--2 (7)')
+      cy.get('@classification').contains('category 1-1--2 (8)')
       cy.get('@classification').contains('category 2-1--1 (1)')
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('10')
 
-      cy.get('@classification').contains('category 1-1--2 (7)').click()
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('7')
+      cy.get('@classification').contains('category 1-1--2 (8)').click()
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('8')
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
+        cy.contains('item a')
         cy.contains('item b')
         cy.contains('item c')
         cy.contains('item d')
@@ -113,8 +114,8 @@ describe('Hierarchical classification', () => {
       cy.get('@classification').contains('category 1-2--3 (3)').click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
 
-      cy.get('@classification').contains('category 1-1--2 (7)').click()
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('7')
+      cy.get('@classification').contains('category 1-1--2 (8)').click()
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('8')
     })
   })
 
@@ -126,13 +127,14 @@ describe('Hierarchical classification', () => {
         .contains('hierarchical classification')
         .click()
 
-      cy.get('@classification').contains('category 1-1--2 (7)').click()
-      cy.get('@classification').contains('category 1-2--1 (2)').click()
+      cy.get('@classification').contains('category 1-1--2 (8)').click()
+      cy.get('@classification').contains('category 1-2--1 (3)').click()
       cy.get('@body').type('{meta}', { release: false })
       cy.get('@classification').contains('category 1-2--3 (3)').click()
 
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('5')
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('6')
       cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
+        cy.contains('item a')
         cy.contains('item b')
         cy.contains('item d')
         cy.contains('item e')

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnomad/classification-selector",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "files": ["lib"],

--- a/packages/classification-selector/src/index.stories.js
+++ b/packages/classification-selector/src/index.stories.js
@@ -22,7 +22,7 @@ const hierarchicalClassifications = [
     type: ClassificationType.Hierarchical,
     categories: [
       { path: ['category 1-1--1'], itemCount: 2, color: '#7fc97f' },
-      { path: ['category 1-1--2', 'category 1-2--1'], itemCount: 2, color: '#beaed4' },
+      { path: ['category 1-1--2', 'category 1-2--1'], itemCount: 3, color: '#beaed4' },
       { path: ['category 1-1--2', 'category 1-2--2'], itemCount: 2, color: '#fdc086' },
       {
         path: ['category 1-1--2', 'category 1-2--3', 'category 1-3--1'],
@@ -40,64 +40,61 @@ const hierarchicalClassifications = [
         color: '#f0027f',
       },
     ],
-    getPathValueOfItem: ({ hierarchicalClassification }) => hierarchicalClassification,
+    getPathValueOfItem: item => item.hierarchicalClassifications,
   },
 ]
 const items = [
   {
     name: 'item a',
     simpleCategory: 'simple category 1',
-    hierarchicalClassification: ['category 1-1--1'],
+    hierarchicalClassifications: [['category 1-1--1'], ['category 1-1--2', 'category 1-2--1']],
   },
   {
     name: 'item b',
     simpleCategory: 'simple category 1',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--1'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--1']],
   },
   {
     name: 'item c',
     simpleCategory: 'simple category 1',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--2'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--2']],
   },
   {
     name: 'item d',
     simpleCategory: 'simple category 2',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--3', 'category 1-3--1'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--3', 'category 1-3--1']],
   },
   {
     name: 'item e',
     simpleCategory: 'simple category 3',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--3', 'category 1-3--2'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--3', 'category 1-3--2']],
   },
   {
     name: 'item f',
     simpleCategory: 'simple category 1',
-    hierarchicalClassification: [
-      'category 2-1--1',
-      'category 2-2--1',
-      'category 2-3--2',
-      'category 2-4--1',
+    hierarchicalClassifications: [
+      ['category 2-1--1', 'category 2-2--1', 'category 2-3--2', 'category 2-4--1'],
     ],
   },
   {
     name: 'item g',
     simpleCategory: 'simple category 2',
-    hierarchicalClassification: ['category 1-1--1'],
+    hierarchicalClassifications: [['category 1-1--1']],
   },
   {
     name: 'item h',
     simpleCategory: 'simple category 3',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--1'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--1']],
   },
   {
     name: 'item i',
     simpleCategory: 'simple category 1',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--2'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--2']],
   },
   {
     name: 'item j',
     simpleCategory: 'simple category 2',
-    hierarchicalClassification: ['category 1-1--2', 'category 1-2--3', 'category 1-3--1'],
+    hierarchicalClassifications: [['category 1-1--2', 'category 1-2--3', 'category 1-3--1']],
   },
 ]
 

--- a/packages/classification-selector/src/types.ts
+++ b/packages/classification-selector/src/types.ts
@@ -27,7 +27,7 @@ export interface HierarchicalCategory {
 export interface HierarchicalClassification<Item> {
   name: string
   type: ClassificationType.Hierarchical
-  getPathValueOfItem: (item: Item) => string[]
+  getPathValueOfItem: (item: Item) => string[][]
   categories: HierarchicalCategory[]
 }
 

--- a/packages/classification-selector/src/useClassificationSelectorState.ts
+++ b/packages/classification-selector/src/useClassificationSelectorState.ts
@@ -141,14 +141,24 @@ export default <Item>({ classifications, items }: Inputs<Item>) => {
       const { getPathValueOfItem } = classification
       for (const { path } of currentHierarchicalCategories) {
         const predicate = (item: Item) => {
-          const itemPathValue = getPathValueOfItem(item)
-          for (let i = 0; i < path.length; i += 1) {
-            if (itemPathValue[i] !== path[i]) {
-              return false
+          const itemPathValues = getPathValueOfItem(item)
+          for (const itemPathValue of itemPathValues) {
+            // For every `path` value that the item belongs to, check to see if
+            // there's a match:
+            let hasFoundDisrepancy = false
+            for (let i = 0; i < path.length; i += 1) {
+              if (itemPathValue[i] !== path[i]) {
+                hasFoundDisrepancy = true
+                break
+              }
+            }
+            if (hasFoundDisrepancy === false) {
+              return true
             }
           }
-          return true
+          return false
         }
+
         predicates.push(predicate)
       }
     }
@@ -199,14 +209,16 @@ export default <Item>({ classifications, items }: Inputs<Item>) => {
     } else {
       const { categories } = classificationForGrouping
       for (const item of filteredItems) {
-        const pathValue = classificationForGrouping.getPathValueOfItem(item)
-        for (const { path, color } of categories) {
-          if (areHierarchicalPathsEqual(pathValue, path) === true) {
-            result.push({
-              ...item,
-              group: serializeHierarchicalPath(pathValue),
-              color,
-            })
+        const pathValues = classificationForGrouping.getPathValueOfItem(item)
+        for (const pathValue of pathValues) {
+          for (const { path, color } of categories) {
+            if (areHierarchicalPathsEqual(pathValue, path) === true) {
+              result.push({
+                ...item,
+                group: serializeHierarchicalPath(pathValue),
+                color,
+              })
+            }
           }
         }
       }


### PR DESCRIPTION
Previously, each item can only belong to a single category of any
classification. That restriction is now lifted so that each item can belong to multiple categories.