### PR TITLE
Improve classification selector

### DIFF
--- a/packages/classification-selector/cypress/integration/classificationViewer.spec.js
+++ b/packages/classification-selector/cypress/integration/classificationViewer.spec.js
@@ -15,7 +15,10 @@ describe('Simple classification', () => {
   })
   it('Select a single category', () => {
     cy.getIframeBody().within(() => {
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('10')
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('11')
+      cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
+        cy.contains('item z')
+      })
 
       cy.get(attr(classificationTreeItemCypressDataAttr))
         .as('classification')
@@ -80,7 +83,11 @@ describe('Hierarchical classification', () => {
       cy.get('@classification').contains('category 1-1--1 (2)')
       cy.get('@classification').contains('category 1-1--2 (8)')
       cy.get('@classification').contains('category 2-1--1 (1)')
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('10')
+
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('11')
+      cy.get(attr(selectedItemsContainerCypressDataAttr)).within(() => {
+        cy.contains('item z')
+      })
 
       cy.get('@classification').contains('category 1-1--2 (8)').click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('8')
@@ -183,18 +190,20 @@ describe('multiple classifications', () => {
 })
 
 describe('select all/none', () => {
-  it('expanding a simple classification, then selecting a category, then "select all" then "select none" should show the same result', () => {
+  it('"select all" should not show items without any category whereas "select none" should show items without any category', () => {
     cy.visit('?path=/story/classification-viewer--select-all-or-none-simple-classification')
     cy.getIframeBody().within(() => {
       cy.get(attr(classificationTreeItemCypressDataAttr))
         .as('classification')
         .contains('simple classification')
         .click()
-      cy.get('@classification').contains('simple category 2 (3)').click()
+
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('4')
+      cy.get('@classification').contains('simple category 2 (1)').click()
       cy.get(attr(selectAllCypressDataAttr)).click()
       cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
       cy.get(attr(selectNoneCypressDataAttr)).click()
-      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('3')
+      cy.get(attr(numFilteredItemsCypressDataAttr)).contains('4')
     })
   })
 

--- a/packages/classification-selector/cypress/integration/classificationViewer.spec.js
+++ b/packages/classification-selector/cypress/integration/classificationViewer.spec.js
@@ -222,3 +222,15 @@ describe('select all/none', () => {
     })
   })
 })
+
+describe('Auto expand first classification', () => {
+  beforeEach(() => {
+    cy.visit('?path=/story/classification-viewer--auto-expand')
+  })
+  it('Auto expand the first classification', () => {
+    cy.getIframeBody().within(() => {
+      cy.get(attr(classificationTreeItemCypressDataAttr)).contains('simple category 1')
+      cy.get(attr(classificationTreeItemCypressDataAttr)).contains('simple category 2')
+    })
+  })
+})

--- a/packages/classification-selector/package.json
+++ b/packages/classification-selector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnomad/classification-selector",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "files": ["lib"],

--- a/packages/classification-selector/src/TestWrapper.tsx
+++ b/packages/classification-selector/src/TestWrapper.tsx
@@ -18,8 +18,13 @@ interface TestItem {
 interface Props<Item extends TestItem>
   extends Omit<ClassificationViewerProps<Item>, 'setFilterPredicates'> {
   items: Item[]
+  shouldAutoExpandFirstClassification: boolean
 }
-function TestWrapper<Item extends TestItem>({ items, classifications }: Props<Item>) {
+function TestWrapper<Item extends TestItem>({
+  items,
+  classifications,
+  shouldAutoExpandFirstClassification,
+}: Props<Item>) {
   const {
     filteredItems,
     selected,
@@ -28,7 +33,7 @@ function TestWrapper<Item extends TestItem>({ items, classifications }: Props<It
     setExpanded,
     clearSelectedCategories,
     selectAllVisibleCategories,
-  } = useInternalState({ items, classifications })
+  } = useInternalState({ items, classifications, shouldAutoExpandFirstClassification })
 
   const filteredElems = filteredItems.map(elem => (
     <Typography align="center" key={elem.name}>

--- a/packages/classification-selector/src/index.stories.js
+++ b/packages/classification-selector/src/index.stories.js
@@ -96,6 +96,11 @@ const items = [
     simpleCategory: 'simple category 2',
     hierarchicalClassifications: [['category 1-1--2', 'category 1-2--3', 'category 1-3--1']],
   },
+  {
+    name: 'item z',
+    simpleCategory: undefined,
+    hierarchicalClassifications: [],
+  },
 ]
 
 export const simpleClassification = () => (
@@ -118,7 +123,19 @@ export const multipleClassifications = () => (
   />
 )
 
-const selectAllSelectNoneSimpleClassificationItems = [
+const selectAllSelectNoneClassifications = [
+  {
+    name: 'simple classification',
+    type: ClassificationType.Simple,
+    categories: [
+      { name: 'simple category 1', itemCount: 1, color: '#7fc97f' },
+      { name: 'simple category 2', itemCount: 1, color: '#beaed4' },
+      { name: 'simple category 3', itemCount: 1, color: '#fdc086' },
+    ],
+    getCategoryValueOfItem: ({ simpleCategory }) => simpleCategory,
+  },
+]
+const selectAllSelectNoneItems = [
   {
     name: 'item a',
     simpleCategory: 'simple category 1',
@@ -131,12 +148,16 @@ const selectAllSelectNoneSimpleClassificationItems = [
     name: 'item c',
     simpleCategory: 'simple category 3',
   },
+  {
+    name: 'item z',
+    simpleCategory: undefined,
+  },
 ]
 
 export const selectAllOrNoneSimpleClassification = () => (
   <TestWrapper
-    items={selectAllSelectNoneSimpleClassificationItems}
-    classifications={[...simpleClassifications]}
+    items={selectAllSelectNoneItems}
+    classifications={[...selectAllSelectNoneClassifications]}
     shouldAutoExpandFirstClassification={false}
   />
 )

--- a/packages/classification-selector/src/index.stories.js
+++ b/packages/classification-selector/src/index.stories.js
@@ -99,7 +99,11 @@ const items = [
 ]
 
 export const simpleClassification = () => (
-  <TestWrapper items={items} classifications={simpleClassifications} />
+  <TestWrapper
+    items={items}
+    classifications={simpleClassifications}
+    shouldAutoExpandFirstClassification={false}
+  />
 )
 
 export const hierarchicalClassification = () => (
@@ -110,6 +114,7 @@ export const multipleClassifications = () => (
   <TestWrapper
     items={items}
     classifications={[...hierarchicalClassifications, ...simpleClassifications]}
+    shouldAutoExpandFirstClassification={false}
   />
 )
 
@@ -132,9 +137,22 @@ export const selectAllOrNoneSimpleClassification = () => (
   <TestWrapper
     items={selectAllSelectNoneSimpleClassificationItems}
     classifications={[...simpleClassifications]}
+    shouldAutoExpandFirstClassification={false}
   />
 )
 
 export const selectAllOrSelectNoneHierarchicalClassification = () => (
-  <TestWrapper items={items} classifications={hierarchicalClassifications} />
+  <TestWrapper
+    items={items}
+    classifications={hierarchicalClassifications}
+    shouldAutoExpandFirstClassification={false}
+  />
+)
+
+export const autoExpand = () => (
+  <TestWrapper
+    items={items}
+    classifications={simpleClassifications}
+    shouldAutoExpandFirstClassification
+  />
 )

--- a/packages/classification-selector/src/types.ts
+++ b/packages/classification-selector/src/types.ts
@@ -15,7 +15,7 @@ export interface SimpleCategory {
 export interface SimpleClassification<Item> {
   name: string
   type: ClassificationType.Simple
-  getCategoryValueOfItem: (item: Item) => string
+  getCategoryValueOfItem: (item: Item) => string | undefined
   categories: SimpleCategory[]
 }
 

--- a/packages/classification-selector/src/useClassificationSelectorState.ts
+++ b/packages/classification-selector/src/useClassificationSelectorState.ts
@@ -62,10 +62,34 @@ const parseSelectedNodeIds = (selectedNodeIds: string[]) => {
 interface Inputs<Item> {
   classifications: Classification<Item>[]
   items: Item[]
+  // Automatically expands the first classification if set to `true`:
+  shouldAutoExpandFirstClassification: boolean
 }
-export default <Item>({ classifications, items }: Inputs<Item>) => {
+export default <Item>({
+  classifications,
+  items,
+  shouldAutoExpandFirstClassification,
+}: Inputs<Item>) => {
   const [selected, setSelected] = useState<string[]>([])
-  const [expanded, setExpanded] = useState<string[]>([])
+  const [expanded, setExpanded] = useState<string[]>(() => {
+    if (shouldAutoExpandFirstClassification === true) {
+      const firstClassification = classifications[0]
+      const classificationNodeId =
+        firstClassification.type === ClassificationType.Simple
+          ? generateNodeId({
+              classificationType: ClassificationType.Simple,
+              type: 'classification',
+              classification: firstClassification.name,
+            })
+          : generateNodeId({
+              classification: firstClassification.name,
+              classificationType: ClassificationType.Hierarchical,
+              type: 'classification',
+            })
+      return [classificationNodeId]
+    }
+    return []
+  })
 
   const {
     selectedNonHollowClassifications: currentClassificationNames,

--- a/packages/classification-selector/src/useClassificationSelectorState.ts
+++ b/packages/classification-selector/src/useClassificationSelectorState.ts
@@ -158,7 +158,13 @@ export default <Item>({
     if (classification.type === ClassificationType.Simple) {
       const { getCategoryValueOfItem } = classification
       for (const { name: categoryName } of currentSimpleCategories) {
-        const predicate = (item: Item) => getCategoryValueOfItem(item) === categoryName
+        const predicate = (item: Item) => {
+          const itemCategory = getCategoryValueOfItem(item)
+          if (itemCategory === undefined) {
+            return false
+          }
+          return itemCategory === categoryName
+        }
         predicates.push(predicate)
       }
     } else if (classification.type === ClassificationType.Hierarchical) {


### PR DESCRIPTION
- Add option to automatically expand the first classification in the classification selector
- Allow items to not belong to any simple or hierarchical category and handle them appropriately.