### PR TITLE
Add option to control how region viewer cursor is rendered

### DIFF
--- a/packages/region-viewer/example/RegionViewerExample.js
+++ b/packages/region-viewer/example/RegionViewerExample.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 
-import { RegionViewer, Track, PositionAxisTrack } from '../src'
+import { RegionViewer, Track, PositionAxisTrack, Cursor } from '../src'
 
 const RegionViewerExample = () => {
   const [position, setPosition] = useState(250)
+  const [lastClickedPosition, setLastClickedPosition] = useState(null)
 
   return (
-    <div>
+    <div style={{ marginTop: '40px' }}>
       <RegionViewer
         width={1000}
         padding={0}
@@ -15,15 +16,17 @@ const RegionViewerExample = () => {
           { feature_type: 'region', start: 200, stop: 300 },
         ]}
       >
-        <Track>
-          {({ scalePosition, width }) => {
-            return (
-              <svg height={50} width={width}>
-                <circle cx={scalePosition(position)} cy={25} r={10} fill="blue" />
-              </svg>
-            )
-          }}
-        </Track>
+        <Cursor onClick={setLastClickedPosition}>
+          <Track>
+            {({ scalePosition, width }) => {
+              return (
+                <svg height={50} width={width}>
+                  <circle cx={scalePosition(position)} cy={25} r={10} fill="blue" />
+                </svg>
+              )
+            }}
+          </Track>
+        </Cursor>
         <PositionAxisTrack />
       </RegionViewer>
 
@@ -41,6 +44,7 @@ const RegionViewerExample = () => {
             }}
           />
         </label>
+        {lastClickedPosition && <p>Clicked position: {lastClickedPosition}</p>}
       </div>
     </div>
   )

--- a/packages/region-viewer/src/Cursor.js
+++ b/packages/region-viewer/src/Cursor.js
@@ -15,7 +15,7 @@ const CursorOverlay = styled.svg`
   pointer-events: none;
 `
 
-export const Cursor = ({ children, onClick }) => {
+export const Cursor = ({ children, onClick, renderCursor }) => {
   const container = useRef()
   const [cursorPosition, setCursorPosition] = useState(null)
 
@@ -59,19 +59,7 @@ export const Cursor = ({ children, onClick }) => {
                 width: `${centerPanelWidth}px`,
               }}
             >
-              {cursorPosition && (
-                <rect
-                  x={cursorPosition - 15}
-                  y={0}
-                  width={30}
-                  height="100%"
-                  fill="none"
-                  stroke="black"
-                  strokeDasharray="5, 5"
-                  strokeWidth={1}
-                  style={{ cursor: 'pointer' }}
-                />
-              )}
+              {cursorPosition && renderCursor(cursorPosition)}
             </CursorOverlay>
             {children}
           </CursorWrapper>
@@ -84,8 +72,21 @@ export const Cursor = ({ children, onClick }) => {
 Cursor.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func.isRequired,
+  renderCursor: PropTypes.func,
 }
 
 Cursor.defaultProps = {
   children: undefined,
+  renderCursor: x => (
+    <rect
+      x={x - 15}
+      y={0}
+      width={30}
+      height="100%"
+      fill="none"
+      stroke="black"
+      strokeDasharray="5, 5"
+      strokeWidth={1}
+    />
+  ),
 }


### PR DESCRIPTION
The gnomAD browser uses the region viewer's Cursor component to navigate the variants table. We got some feedback that the current "window" style is misleading because clicking on the track doesn't actually show the variants contained in the window, it actually scrolls to the variants nearest the center point of the window. See screenshots in broadinstitute/gnomad-browser#583.

This adds a prop to allow changing how the cursor is rendered.

