### PR TITLE
Adjust tooltip hint styles

### DIFF
--- a/packages/ui/src/tooltip/TooltipHint.js
+++ b/packages/ui/src/tooltip/TooltipHint.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const TooltipHint = styled.span`
   background-image: linear-gradient(to right, #000 75%, transparent 75%);
-  background-position: 0 1.04em;
-  background-size: 5px 3px;
+  background-position: 0 1.15em;
+  background-size: 4px 2px;
   background-repeat: repeat-x;
 `

--- a/packages/ui/src/tooltip/TooltipHint.js
+++ b/packages/ui/src/tooltip/TooltipHint.js
@@ -5,4 +5,8 @@ export const TooltipHint = styled.span`
   background-position: 0 1.15em;
   background-size: 4px 2px;
   background-repeat: repeat-x;
+
+  @media print {
+    background-image: none;
+  }
 `


### PR DESCRIPTION
A dashed underline is used to hint that a tooltip with more information is available.

Currently, the underline is close enough to the text that it interferes with legibility. This moves the underline farther away from the text and reduces its size.

Before:
![Screen Shot 2021-02-02 at 8 26 26 AM](https://user-images.githubusercontent.com/1156625/106618106-28fcd200-653d-11eb-9e31-5fde7ddf5c53.png)

After:
![Screen Shot 2021-02-02 at 8 26 47 AM](https://user-images.githubusercontent.com/1156625/106618109-29956880-653d-11eb-83e5-891efe8344a5.png)

It also adds a print media style to hide the underline when the page is printed.