### PR TITLE
Accept a node for default tooltip content

### DIFF
--- a/packages/ui/example/TooltipExample.js
+++ b/packages/ui/example/TooltipExample.js
@@ -1,16 +1,9 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 
 import { TooltipAnchor, TooltipHint } from '../src'
 
-const BasicTooltip = ({ tooltip }) => <span>{tooltip}</span>
-
-BasicTooltip.propTypes = {
-  tooltip: PropTypes.string.isRequired,
-}
-
 const TooltipExample = () => (
-  <TooltipAnchor tooltip="A tooltip" tooltipComponent={BasicTooltip}>
+  <TooltipAnchor tooltip="A tooltip">
     <TooltipHint>Hover here</TooltipHint>
   </TooltipAnchor>
 )

--- a/packages/ui/example/TooltipExample.js
+++ b/packages/ui/example/TooltipExample.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { TooltipAnchor } from '../src'
+import { TooltipAnchor, TooltipHint } from '../src'
 
 const BasicTooltip = ({ tooltip }) => <span>{tooltip}</span>
 
@@ -11,7 +11,7 @@ BasicTooltip.propTypes = {
 
 const TooltipExample = () => (
   <TooltipAnchor tooltip="A tooltip" tooltipComponent={BasicTooltip}>
-    <span>Hover here</span>
+    <TooltipHint>Hover here</TooltipHint>
   </TooltipAnchor>
 )
 

--- a/packages/ui/src/index.d.ts
+++ b/packages/ui/src/index.d.ts
@@ -265,7 +265,7 @@ export const Tabs: React.ComponentType<TabsProps>
 
 /* Start of components exported by DefaultTooltip.js */
 export interface DefaultTooltipProps {
-  tooltip: string
+  tooltip: string | React.ReactNode
 }
 export const DefaultTooltip: React.ComponentType<DefaultTooltipProps>
 /* End of components exported by DefaultTooltip.js */

--- a/packages/ui/src/tooltip/DefaultTooltip.js
+++ b/packages/ui/src/tooltip/DefaultTooltip.js
@@ -11,5 +11,5 @@ const Wrapper = styled.span`
 export const DefaultTooltip = ({ tooltip }) => <Wrapper>{tooltip}</Wrapper>
 
 DefaultTooltip.propTypes = {
-  tooltip: PropTypes.string.isRequired,
+  tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
 }


### PR DESCRIPTION
Currently, the default tooltip component expects a string for tooltip content. However, since it just renders the `tooltip` prop, there's no reason why it can't accept a node as well. This updates prop types and TypeScript types accordingly.