### PR TITLE
Change list style type for ordered list

### DIFF
--- a/packages/ui/src/List.js
+++ b/packages/ui/src/List.js
@@ -10,4 +10,8 @@ export const ListItem = styled.li`
   margin-bottom: 0.5em;
 `
 
-export const OrderedList = List.withComponent('ol')
+export const OrderedList = styled.ol`
+  padding-left: 20px;
+  list-style-type: decimal;
+  margin-bottom: 1em;
+`


### PR DESCRIPTION
Currently, ordered lists use the same disc marker as unordered lists. This changes them to use numbers.

Resolves #9

It also removes this use of [`withComponent`](https://styled-components.com/docs/api#withcomponent), which is a "candidate for deprecation" in styled-components.