### PR TITLE
Accept white space and slashes as separators in region and variant IDs

### DIFF
--- a/packages/identifiers/src/identifiers.spec.js
+++ b/packages/identifiers/src/identifiers.spec.js
@@ -35,6 +35,7 @@ describe('isRegionId', () => {
     '6:391518-3851275',
     '1:55,505,222-55,530,526',
     'm.300',
+    'chr2 500 600',
   ]
 
   const negativeTestCases = ['chr1-', '5-1243421-a', '3-356788-123245', '54-12432-15440']
@@ -56,6 +57,7 @@ describe('parseRegionId', () => {
     { input: '3-10', parsed: { chrom: '3', start: 10, stop: 10 } },
     { input: '1:55,505,222-55,530,526', parsed: { chrom: '1', start: 55505222, stop: 55530526 } },
     { input: 'm.300-320', parsed: { chrom: 'M', start: 300, stop: 320 } },
+    { input: 'chr2 500 600', parsed: { chrom: '2', start: 500, stop: 600 } },
   ]
 
   testCases.forEach(({ input, parsed }) => {
@@ -86,6 +88,7 @@ describe('normalizeRegionId', () => {
     { input: '3-10', normalized: '3-10-10' },
     { input: '1:55,505,222-55,530,526', normalized: '1-55505222-55530526' },
     { input: 'm.300-320', normalized: 'M-300-320' },
+    { input: 'chr2 500 600', normalized: '2-500-600' },
   ]
 
   testCases.forEach(({ input, normalized }) => {
@@ -107,6 +110,7 @@ describe('isVariantId', () => {
     'm.A3243G',
     '3-7643T>C',
     'chr11C308G',
+    '21:47406495 CT>C',
   ]
 
   const negativeTestCases = [
@@ -141,6 +145,7 @@ describe('parseVariantId', () => {
     { input: '3-7643T>C', parsed: { chrom: '3', pos: 7643, ref: 'T', alt: 'C' } },
     { input: 'chr11C308G', parsed: { chrom: '11', pos: 308, ref: 'C', alt: 'G' } },
     { input: '1G55,516,888GA', parsed: { chrom: '1', pos: 55516888, ref: 'G', alt: 'GA' } },
+    { input: '21:47406495 CT>C', parsed: { chrom: '21', pos: 47406495, ref: 'CT', alt: 'C' } },
   ]
 
   testCases.forEach(({ input, parsed }) => {
@@ -185,6 +190,7 @@ describe('normalizeVariantId', () => {
     { input: '3-7643T>C', normalized: '3-7643-T-C' },
     { input: 'chr11C308G', normalized: '11-308-C-G' },
     { input: '1G55,516,888GA', normalized: '1-55516888-G-GA' },
+    { input: '21:47406495 CT>C', normalized: '21-47406495-CT-C' },
   ]
 
   testCases.forEach(({ input, normalized }) => {

--- a/packages/identifiers/src/identifiers.spec.js
+++ b/packages/identifiers/src/identifiers.spec.js
@@ -36,6 +36,7 @@ describe('isRegionId', () => {
     '1:55,505,222-55,530,526',
     'm.300',
     'chr2 500 600',
+    '5/247,300/248,175',
   ]
 
   const negativeTestCases = ['chr1-', '5-1243421-a', '3-356788-123245', '54-12432-15440']
@@ -58,6 +59,7 @@ describe('parseRegionId', () => {
     { input: '1:55,505,222-55,530,526', parsed: { chrom: '1', start: 55505222, stop: 55530526 } },
     { input: 'm.300-320', parsed: { chrom: 'M', start: 300, stop: 320 } },
     { input: 'chr2 500 600', parsed: { chrom: '2', start: 500, stop: 600 } },
+    { input: '5/247,300/248,175', parsed: { chrom: '5', start: 247300, stop: 248175 } },
   ]
 
   testCases.forEach(({ input, parsed }) => {
@@ -89,6 +91,7 @@ describe('normalizeRegionId', () => {
     { input: '1:55,505,222-55,530,526', normalized: '1-55505222-55530526' },
     { input: 'm.300-320', normalized: 'M-300-320' },
     { input: 'chr2 500 600', normalized: '2-500-600' },
+    { input: '5/247,300/248,175', normalized: '5-247300-248175' },
   ]
 
   testCases.forEach(({ input, normalized }) => {
@@ -111,6 +114,7 @@ describe('isVariantId', () => {
     '3-7643T>C',
     'chr11C308G',
     '21:47406495 CT>C',
+    '1:55516888  G/GA',
   ]
 
   const negativeTestCases = [
@@ -146,6 +150,7 @@ describe('parseVariantId', () => {
     { input: 'chr11C308G', parsed: { chrom: '11', pos: 308, ref: 'C', alt: 'G' } },
     { input: '1G55,516,888GA', parsed: { chrom: '1', pos: 55516888, ref: 'G', alt: 'GA' } },
     { input: '21:47406495 CT>C', parsed: { chrom: '21', pos: 47406495, ref: 'CT', alt: 'C' } },
+    { input: '1:55516888  G/GA', parsed: { chrom: '1', pos: 55516888, ref: 'G', alt: 'GA' } },
   ]
 
   testCases.forEach(({ input, parsed }) => {
@@ -191,6 +196,7 @@ describe('normalizeVariantId', () => {
     { input: 'chr11C308G', normalized: '11-308-C-G' },
     { input: '1G55,516,888GA', normalized: '1-55516888-G-GA' },
     { input: '21:47406495 CT>C', normalized: '21-47406495-CT-C' },
+    { input: '1:55516888  G/GA', normalized: '1-55516888-G-GA' },
   ]
 
   testCases.forEach(({ input, normalized }) => {

--- a/packages/identifiers/src/identifiers.ts
+++ b/packages/identifiers/src/identifiers.ts
@@ -1,4 +1,11 @@
-const REGION_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]([\d,]+)([-:]([\d,]+)?)?$/i
+const CHROMOSOME = '(?:chr)?(?:\\d+|x|y|m|mt)'
+const POSITION = '[\\d,]+'
+const SEPARATOR = '[-:.]'
+
+const REGION_ID_REGEX = new RegExp(
+  `(${CHROMOSOME})${SEPARATOR}(${POSITION})(?:${SEPARATOR}(${POSITION})?)?$`,
+  'i'
+)
 
 export const parseRegionId = (regionId: string) => {
   const match = REGION_ID_REGEX.exec(regionId)
@@ -6,14 +13,14 @@ export const parseRegionId = (regionId: string) => {
     throw new Error('Invalid region ID')
   }
 
-  const chrom = match[2].toUpperCase()
+  const chrom = match[1].toUpperCase().replace(/^chr/i, '')
   const chromNumber = Number(chrom)
   if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
     throw new Error('Invalid region ID')
   }
 
-  const start = Number(match[3].replace(/,/g, ''))
-  const stop = match[5] ? Number(match[5].replace(/,/g, '')) : start
+  const start = Number(match[2].replace(/,/g, ''))
+  const stop = match[3] ? Number(match[3].replace(/,/g, '')) : start
 
   if (stop < start) {
     throw new Error('Invalid region ID')
@@ -36,7 +43,12 @@ export const isRegionId = (str: string) => {
   }
 }
 
-const VARIANT_ID_REGEX = /^(chr)?(\d+|x|y|m|mt)[-:.]?((([\d,]+)[-:.]?([acgt]+)[-:.>]([acgt]+))|(([acgt]+)[-:.]?([\d,]+)[-:.]?([acgt]+)))$/i
+const ALLELE = '[acgt]+'
+
+const VARIANT_ID_REGEX = new RegExp(
+  `^(${CHROMOSOME})${SEPARATOR}?(?:((${POSITION})${SEPARATOR}?(${ALLELE})(?:${SEPARATOR}|>)(${ALLELE}))|((${ALLELE})${SEPARATOR}?(${POSITION})${SEPARATOR}?(${ALLELE})))$`,
+  'i'
+)
 
 export const parseVariantId = (variantId: string) => {
   const match = VARIANT_ID_REGEX.exec(variantId)
@@ -44,7 +56,7 @@ export const parseVariantId = (variantId: string) => {
     throw new Error('Invalid variant ID')
   }
 
-  const chrom = match[2].toUpperCase()
+  const chrom = match[1].toUpperCase().replace(/^chr/i, '')
   const chromNumber = Number(chrom)
   if (!Number.isNaN(chromNumber) && (chromNumber < 1 || chromNumber > 22)) {
     throw new Error('Invalid variant ID')
@@ -55,16 +67,16 @@ export const parseVariantId = (variantId: string) => {
   let alt
 
   /* eslint-disable prefer-destructuring */
-  if (match[4]) {
+  if (match[2]) {
     // chrom-pos-ref-alt
-    pos = match[5]
-    ref = match[6]
-    alt = match[7]
+    pos = match[3]
+    ref = match[4]
+    alt = match[5]
   } else {
     // chrom-ref-pos-alt
-    ref = match[9]
-    pos = match[10]
-    alt = match[11]
+    ref = match[7]
+    pos = match[8]
+    alt = match[9]
   }
   /* eslint-enable prefer-destructuring */
 

--- a/packages/identifiers/src/identifiers.ts
+++ b/packages/identifiers/src/identifiers.ts
@@ -1,6 +1,6 @@
 const CHROMOSOME = '(?:chr)?(?:\\d+|x|y|m|mt)'
 const POSITION = '[\\d,]+'
-const SEPARATOR = '[-:.]'
+const SEPARATOR = '(?:[-:.]|\\s+)'
 
 const REGION_ID_REGEX = new RegExp(
   `(${CHROMOSOME})${SEPARATOR}(${POSITION})(?:${SEPARATOR}(${POSITION})?)?$`,

--- a/packages/identifiers/src/identifiers.ts
+++ b/packages/identifiers/src/identifiers.ts
@@ -1,6 +1,6 @@
 const CHROMOSOME = '(?:chr)?(?:\\d+|x|y|m|mt)'
 const POSITION = '[\\d,]+'
-const SEPARATOR = '(?:[-:.]|\\s+)'
+const SEPARATOR = '(?:[-:./]|\\s+)'
 
 const REGION_ID_REGEX = new RegExp(
   `(${CHROMOSOME})${SEPARATOR}(${POSITION})(?:${SEPARATOR}(${POSITION})?)?$`,


### PR DESCRIPTION
Support variant IDs like 1:55516888 G/GA

Resolves #29

This also store regexes for parts of IDs (chromosome, position, allele, separator) in variables to make the overall regexes easier to understand. And uses [non-capturing groups](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges) for groups that aren't needed for the final result.