### PR TITLE
Allow customizing how gene labels in genes track are rendered

### DIFF
--- a/packages/track-genes/example/GenesTrackExample.js
+++ b/packages/track-genes/example/GenesTrackExample.js
@@ -17,7 +17,14 @@ const regions = [
 
 const GenesTrackExample = () => (
   <RegionViewer padding={0} regions={regions} width={1000}>
-    <GenesTrack genes={genes} />
+    <GenesTrack
+      genes={genes}
+      renderGeneLabel={gene => (
+        <a href={`https://gnomad.broadinstitute.org/gene/${gene.gene_id}`}>
+          <text textAnchor="middle">{gene.symbol}</text>
+        </a>
+      )}
+    />
   </RegionViewer>
 )
 

--- a/packages/track-genes/src/GenesPlot.js
+++ b/packages/track-genes/src/GenesPlot.js
@@ -1,15 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
-
-const GeneName = styled.text`
-  fill: #428bca;
-
-  &:hover {
-    fill: #be4248;
-    cursor: pointer;
-  }
-`
 
 const layoutRows = (genes, scalePosition) => {
   if (genes.length === 0) {
@@ -67,26 +57,28 @@ const featureTypeCompareFn = (r1, r2) =>
 
 const isCodingGene = gene => gene.exons.some(exon => exon.feature_type === 'CDS')
 
-export const GenesPlot = ({ genes, includeNonCodingGenes, onGeneClick, scalePosition, width }) => {
+export const GenesPlot = ({
+  genes,
+  includeNonCodingGenes,
+  renderGeneLabel,
+  scalePosition,
+  width,
+}) => {
   const rows = layoutRows(includeNonCodingGenes ? genes : genes.filter(isCodingGene), scalePosition)
   const rowHeight = 50
   return (
     <svg height={rowHeight * rows.length} width={width}>
       {rows.map((track, trackNumber) =>
         track.map(gene => {
-          const textYPosition = rowHeight * trackNumber + 33
+          const labelY = rowHeight * trackNumber + 33
           const exonsYPosition = rowHeight * trackNumber + 8
           const geneStart = scalePosition(gene.start)
           const geneStop = scalePosition(gene.stop)
           return (
             <g key={gene.gene_id}>
-              <GeneName
-                x={(geneStop + geneStart) / 2}
-                y={textYPosition}
-                onClick={() => onGeneClick(gene)}
-              >
-                {gene.symbol}
-              </GeneName>
+              <g transform={`translate(${(geneStart + geneStop) / 2},${labelY})`}>
+                {renderGeneLabel(gene)}
+              </g>
               <line
                 x1={geneStart}
                 x2={geneStop}
@@ -124,7 +116,6 @@ GenesPlot.propTypes = {
   genes: PropTypes.arrayOf(
     PropTypes.shape({
       gene_id: PropTypes.string.isRequired,
-      symbol: PropTypes.string.isRequired,
       start: PropTypes.number.isRequired,
       stop: PropTypes.number.isRequired,
       exons: PropTypes.arrayOf(
@@ -137,12 +128,12 @@ GenesPlot.propTypes = {
     })
   ).isRequired,
   includeNonCodingGenes: PropTypes.bool,
-  onGeneClick: PropTypes.func,
+  renderGeneLabel: PropTypes.func,
   scalePosition: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 }
 
 GenesPlot.defaultProps = {
   includeNonCodingGenes: false,
-  onGeneClick: () => {},
+  renderGeneLabel: gene => <text textAnchor="middle">{gene.symbol}</text>,
 }

--- a/packages/track-genes/src/GenesTrack.js
+++ b/packages/track-genes/src/GenesTrack.js
@@ -12,14 +12,14 @@ const TitlePanel = styled.div`
   justify-content: flex-start;
 `
 
-export const GenesTrack = ({ genes, includeNonCodingGenes, onGeneClick, title }) => (
+export const GenesTrack = ({ genes, includeNonCodingGenes, renderGeneLabel, title }) => (
   <Track renderLeftPanel={() => <TitlePanel>{title}</TitlePanel>}>
     {({ scalePosition, width }) => {
       return (
         <GenesPlot
           genes={genes}
           includeNonCodingGenes={includeNonCodingGenes}
-          onGeneClick={onGeneClick}
+          renderGeneLabel={renderGeneLabel}
           scalePosition={scalePosition}
           width={width}
         />
@@ -32,7 +32,6 @@ GenesTrack.propTypes = {
   genes: PropTypes.arrayOf(
     PropTypes.shape({
       gene_id: PropTypes.string.isRequired,
-      symbol: PropTypes.string.isRequired,
       start: PropTypes.number.isRequired,
       stop: PropTypes.number.isRequired,
       exons: PropTypes.arrayOf(
@@ -45,12 +44,12 @@ GenesTrack.propTypes = {
     })
   ).isRequired,
   includeNonCodingGenes: PropTypes.bool,
-  onGeneClick: PropTypes.func,
+  renderGeneLabel: PropTypes.func,
   title: PropTypes.string,
 }
 
 GenesTrack.defaultProps = {
   includeNonCodingGenes: false,
-  onGeneClick: () => {},
+  renderGeneLabel: undefined,
   title: 'Genes',
 }


### PR DESCRIPTION
In the gnomAD browser, on the region page, clicking on a gene in the genes track navigates to the gene page for that gene. This is currently handled with an onClick listener on the label's `<text>` element. However, using link elements would be preferable for accessibility.

To make the genes track more flexible, this replaces GenesPlot's `onGeneClick` prop with an `renderGeneLabel` prop which allows the consumer to customize how labels are rendered.