### PR TITLE
Rewrite region-viewer's position scale

### DIFF
--- a/packages/region-viewer/package.json
+++ b/packages/region-viewer/package.json
@@ -21,9 +21,7 @@
     "example": "gnomad-browser-toolkit-scripts example"
   },
   "dependencies": {
-    "d3-scale": "^2.2.2",
-    "prop-types": "^15.7.2",
-    "ramda": "^0.24.1"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.9.0",

--- a/packages/region-viewer/src/Track.js
+++ b/packages/region-viewer/src/Track.js
@@ -58,7 +58,7 @@ export const Track = ({ children, renderLeftPanel, renderRightPanel, renderTopPa
       centerPanelWidth,
       isPositionDefined,
       leftPanelWidth,
-      offsetRegions,
+      regions,
       rightPanelWidth,
       scalePosition,
     }) => (
@@ -81,7 +81,7 @@ export const Track = ({ children, renderLeftPanel, renderRightPanel, renderTopPa
               ...rest,
               isPositionDefined,
               leftPanelWidth,
-              offsetRegions,
+              regions,
               rightPanelWidth,
               scalePosition,
               width: centerPanelWidth,

--- a/packages/region-viewer/src/coordinates.js
+++ b/packages/region-viewer/src/coordinates.js
@@ -1,33 +1,14 @@
-import R from 'ramda'
-import { scaleLinear } from 'd3-scale'
-
-const sortRegions = regions => [...regions].sort((r1, r2) => r1.start - r2.start)
-
-export const calculateRegionDistances = regions =>
-  regions.map((region, i) => {
-    if (i === 0) {
-      return {
-        ...region,
-        previousRegionDistance: Infinity,
-      }
-    }
-    return {
-      ...region,
-      previousRegionDistance: region.start - regions[i - 1].stop,
-    }
-  })
-
-const mergeOverlappingRegions = sortedRegions => {
-  if (sortedRegions.length === 0) {
+export const mergeOverlappingRegions = regions => {
+  if (regions.length === 0) {
     return []
   }
 
-  const mergedRegions = [{ ...sortedRegions[0] }]
+  const mergedRegions = [{ ...regions[0] }]
 
   let previousRegion = mergedRegions[0]
 
-  for (let i = 1; i < sortedRegions.length; i += 1) {
-    const nextRegion = sortedRegions[i]
+  for (let i = 1; i < regions.length; i += 1) {
+    const nextRegion = regions[i]
 
     if (nextRegion.start <= previousRegion.stop + 1) {
       if (nextRegion.stop > previousRegion.stop) {
@@ -42,100 +23,43 @@ const mergeOverlappingRegions = sortedRegions => {
   return mergedRegions
 }
 
-export const addPadding = R.curry((padding, regions) => {
-  if (padding === 0) return regions
-  return regions.reduce((acc, region) => {
-    const startPad = {
-      feature_type: 'start_pad',
-      start: region.start - padding,
-      stop: region.start - 1,
-    }
+export const regionViewerScale = (domainRegions, range) => {
+  const totalRegionSize = domainRegions.reduce(
+    (acc, region) => acc + (region.stop - region.start + 1),
+    0
+  )
 
-    const endPad = {
-      feature_type: 'end_pad',
-      start: region.stop + 1,
-      stop: region.stop + padding,
-    }
+  const scale = position => {
+    const distanceToPosition = domainRegions
+      .filter(region => region.start <= position)
+      .reduce(
+        (acc, region) =>
+          region.start <= position && position <= region.stop
+            ? acc + position - region.start
+            : acc + (region.stop - region.start + 1),
+        0
+      )
 
-    // check if total padding greater than distance between exons
-    if (region.previousRegionDistance < padding * 2) {
-      return [
-        ...R.init(acc), // remove previous end_pad
-        {
-          feature_type: 'intron',
-          start: region.start - region.previousRegionDistance,
-          stop: region.start - 1,
-        },
-        region,
-        endPad,
-      ]
-    }
-    return [...acc, startPad, region, endPad]
-  }, [])
-})
+    return range[0] + (range[1] - range[0]) * (distanceToPosition / totalRegionSize)
+  }
 
-export const calculateOffset = R.curry(regions =>
-  regions.reduce((acc, region, i) => {
-    if (i === 0) return [{ ...region, offset: 0 }]
-    return [
-      ...acc,
-      {
-        ...region,
-        offset: acc[i - 1].offset + (region.start - acc[i - 1].stop),
-      },
-    ]
-  }, [])
-)
+  scale.invert = x => {
+    const clampedX = Math.max(Math.min(x, range[1]), range[0])
+    let distanceToPosition = Math.floor(
+      totalRegionSize * ((clampedX - range[0]) / (range[1] - range[0]))
+    )
 
-export const calculateOffsetRegions = (padding = 50, regions) =>
-  R.pipe(
-    sortRegions,
-    mergeOverlappingRegions,
-    calculateRegionDistances,
-    addPadding(padding),
-    calculateOffset
-  )(regions)
-
-export const calculatePositionOffset = R.curry((regions, position) => {
-  const lastRegionBeforePosition = R.findLast(region => region.start <= position)(regions)
-
-  if (lastRegionBeforePosition) {
-    // Position is within a region
-    if (position < lastRegionBeforePosition.stop) {
-      return {
-        offsetPosition: position - lastRegionBeforePosition.offset,
+    for (let i = 0; i < domainRegions.length; i += 1) {
+      const region = domainRegions[i]
+      const regionSize = region.stop - region.start + 1
+      if (distanceToPosition < regionSize) {
+        return region.start + distanceToPosition
       }
+      distanceToPosition -= regionSize
     }
 
-    // Position is between regions
-    return {
-      offsetPosition: lastRegionBeforePosition.stop - lastRegionBeforePosition.offset,
-    }
+    return domainRegions[domainRegions.length - 1].stop
   }
 
-  // Position is before first region
-  return {
-    offsetPosition: regions[0].start - regions[0].offset,
-  }
-})
-
-export const invertPositionOffset = R.curry((regions, xScale, scaledPosition) => {
-  let result = 0
-  for (let i = 0; i < regions.length; i += 1) {
-    if (
-      scaledPosition >= xScale(regions[i].start - regions[i].offset) &&
-      scaledPosition <= xScale(regions[i].stop - regions[i].offset)
-    ) {
-      result = Math.floor(xScale.invert(scaledPosition) + regions[i].offset)
-    }
-  }
-  return result
-})
-
-export const calculateXScale = (width, offsetRegions) =>
-  scaleLinear()
-    .domain([
-      offsetRegions[0].start,
-      offsetRegions[offsetRegions.length - 1].stop - offsetRegions[offsetRegions.length - 1].offset,
-    ])
-    .range([0, width])
+  return scale
+}

--- a/packages/region-viewer/src/coordinates.spec.js
+++ b/packages/region-viewer/src/coordinates.spec.js
@@ -1,166 +1,155 @@
-import R from 'ramda'
+import { mergeOverlappingRegions, regionViewerScale } from './coordinates'
 
-import { addPadding, calculateOffset } from './coordinates'
+describe('mergeOverlappingRegions', () => {
+  it('should merge overlapping regions', () => {
+    expect(
+      mergeOverlappingRegions([
+        { start: 5, stop: 10 },
+        { start: 7, stop: 12 },
+        { start: 10, stop: 11 },
+      ])
+    ).toEqual([{ start: 5, stop: 12 }])
+  })
 
-const REGIONS = [
-  {
-    feature_type: 'exon',
-    start: 46546500,
-    stop: 46546556,
-  },
-  {
-    feature_type: 'exon',
-    start: 46547792,
-    stop: 46547957,
-  },
-  {
-    feature_type: 'exon',
-    start: 46594240,
-    stop: 46594489,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46594282,
-    stop: 46594489,
-  },
-  {
-    feature_type: 'exon',
-    start: 46611071,
-    stop: 46611231,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46611071,
-    stop: 46611231,
-  },
-  {
-    feature_type: 'exon',
-    start: 46614161,
-    stop: 46614299,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46614161,
-    stop: 46614299,
-  },
-  {
-    feature_type: 'exon',
-    start: 46615710,
-    stop: 46615912,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46615710,
-    stop: 46615912,
-  },
-  {
-    feature_type: 'exon',
-    start: 46627690,
-    stop: 46628137,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46627690,
-    stop: 46628137,
-  },
-  {
-    feature_type: 'exon',
-    start: 46631031,
-    stop: 46639654,
-  },
-  {
-    feature_type: 'CDS',
-    start: 46631031,
-    stop: 46631275,
-  },
-  {
-    feature_type: 'UTR',
-    start: 46546500,
-    stop: 46546556,
-  },
-  {
-    feature_type: 'UTR',
-    start: 46547792,
-    stop: 46547957,
-  },
-  {
-    feature_type: 'UTR',
-    start: 46594240,
-    stop: 46594281,
-  },
-  {
-    feature_type: 'UTR',
-    start: 46631276,
-    stop: 46639654,
-  },
-]
+  it('should merge adjacent regions', () => {
+    expect(
+      mergeOverlappingRegions([
+        { start: 5, stop: 10 },
+        { start: 11, stop: 14 },
+        { start: 17, stop: 22 },
+        { start: 22, stop: 24 },
+      ])
+    ).toEqual([
+      { start: 5, stop: 14 },
+      { start: 17, stop: 24 },
+    ])
+  })
 
-describe('calculateOffset', () => {
-  const filteredRegions = REGIONS.filter(exon => exon.feature_type === 'CDS')
-  const offsetRegions = calculateOffset(filteredRegions)
-  it('adds 0 offset attribute to first region', () => {
-    expect(offsetRegions[0].offset).toBe(0)
-  })
-  it('adds offset attribute, first region', () => {
-    expect(offsetRegions[0]).toEqual({
-      feature_type: 'CDS',
-      offset: 0,
-      start: 46594282,
-      stop: 46594489,
-    })
-  })
-  it('adds offset attribute, second region', () => {
-    expect(offsetRegions[1]).toEqual({
-      feature_type: 'CDS',
-      offset: 16582,
-      start: 46611071,
-      stop: 46611231,
-    })
-  })
-  it('adds offset attribute, third region', () => {
-    expect(offsetRegions[2]).toEqual({
-      feature_type: 'CDS',
-      offset: 19512,
-      start: 46614161,
-      stop: 46614299,
-    })
-  })
-  it('second region offset equal to second region start - first region stop', () => {
-    expect(offsetRegions[1].offset).toBe(offsetRegions[1].start - offsetRegions[0].stop)
-  })
-  it('third region offset equal to third region start - second region stop + second region offset', () => {
-    expect(offsetRegions[3].offset).toBe(
-      offsetRegions[3].start - offsetRegions[2].stop + offsetRegions[2].offset
-    )
+  it('should handle empty list', () => {
+    expect(mergeOverlappingRegions([])).toEqual([])
   })
 })
 
-describe('addPadding', () => {
-  const filteredRegions = REGIONS.filter(exon => exon.feature_type === 'CDS')
-  const add50Bases = addPadding(50)
-  it('adds padding regions', () => {
-    expect(R.pipe(add50Bases, R.pluck('feature_type'))(filteredRegions)).toEqual([
-      'start_pad',
-      'CDS',
-      'end_pad',
-      'start_pad',
-      'CDS',
-      'end_pad',
-      'start_pad',
-      'CDS',
-      'end_pad',
-      'start_pad',
-      'CDS',
-      'end_pad',
-      'start_pad',
-      'CDS',
-      'end_pad',
-      'start_pad',
-      'CDS',
-      'end_pad',
-    ])
+describe('regionViewerScale', () => {
+  it('maps positions in regions to range values', () => {
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(2)
+    ).toEqual(1)
+
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(12)
+    ).toEqual(7)
   })
-  it('offset added', () => {
-    R.pipe(add50Bases, calculateOffset)(filteredRegions)
+
+  it('maps positions between regions to a point', () => {
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(7)
+    ).toEqual(5)
+
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(9)
+    ).toEqual(5)
+  })
+
+  it('clamps return values to range', () => {
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(-5)
+    ).toEqual(0)
+
+    expect(
+      regionViewerScale(
+        [
+          { start: 1, stop: 5 },
+          { start: 10, stop: 14 },
+        ],
+        [0, 10]
+      )(20)
+    ).toEqual(10)
+  })
+
+  describe('invert', () => {
+    it('maps range values to domain values', () => {
+      expect(
+        regionViewerScale(
+          [
+            { start: 1, stop: 5 },
+            { start: 10, stop: 14 },
+          ],
+          [0, 10]
+        ).invert(1)
+      ).toEqual(2)
+
+      expect(
+        regionViewerScale(
+          [
+            { start: 1, stop: 5 },
+            { start: 10, stop: 14 },
+          ],
+          [0, 10]
+        ).invert(7)
+      ).toEqual(12)
+
+      expect(
+        regionViewerScale(
+          [
+            { start: 1, stop: 5 },
+            { start: 10, stop: 14 },
+          ],
+          [0, 10]
+        ).invert(5)
+      ).toEqual(10)
+    })
+
+    it('clamps values outside range to domain', () => {
+      expect(
+        regionViewerScale(
+          [
+            { start: 1, stop: 5 },
+            { start: 10, stop: 14 },
+          ],
+          [0, 10]
+        ).invert(-1)
+      ).toEqual(1)
+
+      expect(
+        regionViewerScale(
+          [
+            { start: 1, stop: 5 },
+            { start: 10, stop: 14 },
+          ],
+          [0, 10]
+        ).invert(11)
+      ).toEqual(14)
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10701,11 +10701,6 @@ ramda@^0.21.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
 
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
-  integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"


### PR DESCRIPTION
Ramda is a pretty heavy dependency relative to what it's used for in region-viewer. This refactors creating the `scalePosition` function used to map genomic positions to x coordinates and drops Ramda as a dependency.

Breaking changes:
- `offsetPositions` is no longer passed down to tracks. It is replaced by `regions`, which includes most of the same information except for the `offset` field on regions, which previously contained a cumulative count of how much distance was skipped between previous regions. The coverage track in gnomAD currently uses this, but its use can be replaced with `regions` and `isPositionDefined`.
- `positionOffset` is no longer passed down to tracks. For the most part, it was only useful when used with `xScale`. `scalePosition` can be used to directly map genomic position to x coordinate. I don't know of any tracks that used this.

To try this out, view the example with `yarn workspace '@gnomad/region-viewer' run example`.

Or to try it in a browser, run `yarn workspace '@gnomad/region-viewer' run build` to build the package and add the following to the browser's webpack configuration:
```js
config.resolve = {
  alias: {
    // Resolve region-viewer from the gnomad-browser-toolkit repository
    '@gnomad/region-viewer': '/path/to/gnomad-browser-toolkit/packages/region-viewer',
    // Prevent region-viewer from bringing in another copy of React and styled-components
    'react': require.resolve('react'),
    'styled-components': require.resolve('styled-components'),
  }
}
```