### PR TITLE
Add fallback if Unicode is not supported in regular expressions

### DIFF
--- a/packages/identifiers/src/identifiers.ts
+++ b/packages/identifiers/src/identifiers.ts
@@ -1,10 +1,23 @@
+// The Unicode flag is not supported in IE 11.
+const isRegExpUnicodeFlagSupported = (() => {
+  try {
+    new RegExp('test', 'u') // eslint-disable-line no-new
+    return true
+  } catch (err) {
+    return false
+  }
+})()
+
 const CHROMOSOME = '(?:chr)?(?:\\d+|x|y|m|mt)'
 const POSITION = '[\\d,]+'
-const SEPARATOR = '(?:\\p{Pd}|[:./]|\\s+)'
+const DASH = isRegExpUnicodeFlagSupported ? '\\p{Pd}' : '-'
+const SEPARATOR = `(?:${DASH}|[:./]|\\s+)`
+
+const REGEXP_FLAGS = `i${isRegExpUnicodeFlagSupported ? 'u' : ''}`
 
 const REGION_ID_REGEX = new RegExp(
   `(${CHROMOSOME})${SEPARATOR}(${POSITION})(?:${SEPARATOR}(${POSITION})?)?$`,
-  'iu'
+  REGEXP_FLAGS
 )
 
 export const parseRegionId = (regionId: string) => {
@@ -47,7 +60,7 @@ const ALLELE = '[acgt]+'
 
 const VARIANT_ID_REGEX = new RegExp(
   `^(${CHROMOSOME})${SEPARATOR}?(?:((${POSITION})${SEPARATOR}?(${ALLELE})(?:${SEPARATOR}|>)(${ALLELE}))|((${ALLELE})${SEPARATOR}?(${POSITION})${SEPARATOR}?(${ALLELE})))$`,
-  'iu'
+  REGEXP_FLAGS
 )
 
 export const parseVariantId = (variantId: string) => {


### PR DESCRIPTION
#51 added support for Unicode dashes in variant/region IDs. However, the Unicode RegExp flag is not supported in IE 11. This adds a check if that flag is supported and falls back to using "-" instead of a Unicode property if it is not supported.

Resolves #57