### PR TITLE
Adds new issues and PRs to the browser project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,25 @@
+name: Add issues and PRs to browser project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/broadinstitute/projects/29
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: andymckay/labeler@5c59dabdfd4dd5bd9c6e6d255b01b9d764af4414
+        with:
+          add-labels: "Triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a new action that runs when new issues or pull requests are opened. The intention is:

The issue/PR is labeled with the "Triage" label
The issue/PR is added to the gnomad-browser-team project board.