### PR TITLE
use pull_request_target

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
dependabot PRs execute with different permissions since they originate from an external fork. This updates the action to use an event that runs in the context target repository that the PR is being created against, which should allow it to modify issues/labels/projects etc.