### PR TITLE
update dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 #  - Disables non-security update PRs
-#  - Schedules security update PRs daily
+#  - Schedules security update PRs weekly
 #  - Auto assigns PRs to the gnomad-browser team
 
 version: 2
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     # Disable version updates for npm dependencies
     open-pull-requests-limit: 0
     reviewers:


### PR DESCRIPTION
Reducing the frequency of the security updates to weekly -- I've also enabled the repository's security update grouping setting, which should theoretically have it do all its updates in one PR.